### PR TITLE
약속 상세화면 리팩토링 및 뒤로가기 기능 구현

### DIFF
--- a/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
@@ -36,6 +36,9 @@ class DefaultPromiseRepository @Inject constructor(
     override suspend fun getPromiseByCode(promiseCode: String): Result<PromiseModel> =
         firebaseDataSource.getPromiseByCode(promiseCode)
 
+    override suspend fun getPromiseByCodeAndListen(promiseCode: String): Flow<Result<PromiseModel>> =
+        firebaseDataSource.getPromiseByCodeAndListen(promiseCode)
+
     override suspend fun setUserLocation(userLocationModel: UserLocationModel): Result<Unit> =
         firebaseDataSource.setUserLocation(userLocationModel)
 

--- a/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
@@ -9,6 +9,8 @@ interface PromiseRepository {
 
     suspend fun getPromiseByCode(promiseCode: String): Result<PromiseModel>
 
+    suspend fun getPromiseByCodeAndListen(promiseCode: String): Flow<Result<PromiseModel>>
+
     suspend fun setPromise(promiseDataModel: PromiseDataModel): Result<String>
 
     suspend fun setUserLocation(userLocationModel: UserLocationModel): Result<Unit>

--- a/data/src/main/kotlin/com/woory/data/source/FirebaseDataSource.kt
+++ b/data/src/main/kotlin/com/woory/data/source/FirebaseDataSource.kt
@@ -11,6 +11,8 @@ interface FirebaseDataSource {
 
     suspend fun getPromiseByCode(code: String): Result<PromiseModel>
 
+    suspend fun getPromiseByCodeAndListen(code: String): Flow<Result<PromiseModel>>
+
     suspend fun setPromise(promiseDataModel: PromiseDataModel): Result<String>
 
     suspend fun getUserLocationById(id: String): Flow<Result<UserLocationModel>>

--- a/firebase/src/main/kotlin/com/woory/firebase/datasource/DefaultFirebaseDataSource.kt
+++ b/firebase/src/main/kotlin/com/woory/firebase/datasource/DefaultFirebaseDataSource.kt
@@ -12,6 +12,7 @@ import com.woory.data.model.UserModel
 import com.woory.data.source.FirebaseDataSource
 import com.woory.firebase.mapper.asDomain
 import com.woory.firebase.mapper.asModel
+import com.woory.firebase.mapper.asPromiseParticipant
 import com.woory.firebase.model.PromiseDocument
 import com.woory.firebase.model.UserHpDocument
 import com.woory.firebase.model.UserLocationDocument
@@ -212,7 +213,7 @@ class DefaultFirebaseDataSource @Inject constructor(
                 val res = fireStore
                     .collection("Promises")
                     .document(code)
-                    .update("users", FieldValue.arrayUnion(user))
+                    .update("users", FieldValue.arrayUnion(user.asPromiseParticipant()))
                     .await()
             }
 

--- a/firebase/src/main/kotlin/com/woory/firebase/datasource/DefaultFirebaseDataSource.kt
+++ b/firebase/src/main/kotlin/com/woory/firebase/datasource/DefaultFirebaseDataSource.kt
@@ -58,7 +58,7 @@ class DefaultFirebaseDataSource @Inject constructor(
         callbackFlow {
             var documentReference: DocumentReference? = null
 
-            kotlin.runCatching {
+            runCatching {
                 documentReference = fireStore.collection("Promises").document(code)
             }.onFailure {
                 trySend(Result.failure(it))
@@ -69,7 +69,7 @@ class DefaultFirebaseDataSource @Inject constructor(
                     return@addSnapshotListener
                 }
 
-                kotlin.runCatching {
+                runCatching {
                     val result = value.toObject(PromiseDocument::class.java)
                     result?.let {
                         trySend(Result.success(it.asDomain()))
@@ -99,7 +99,7 @@ class DefaultFirebaseDataSource @Inject constructor(
             }
             requireNotNull(generatedCode)
 
-            val result = kotlin.runCatching {
+            val result = runCatching {
                 fireStore
                     .collection("Promises")
                     .document(generatedCode)
@@ -117,7 +117,7 @@ class DefaultFirebaseDataSource @Inject constructor(
         callbackFlow {
             var documentReference: DocumentReference? = null
 
-            kotlin.runCatching {
+            runCatching {
                 documentReference = fireStore.collection("UserLocation").document(id)
             }.onFailure {
                 trySend(Result.failure(it))
@@ -128,7 +128,7 @@ class DefaultFirebaseDataSource @Inject constructor(
                     return@addSnapshotListener
                 }
 
-                kotlin.runCatching {
+                runCatching {
                     val result = value.toObject(UserLocationDocument::class.java)
                     result?.let {
                         trySend(Result.success(it.asDomain()))
@@ -143,7 +143,7 @@ class DefaultFirebaseDataSource @Inject constructor(
 
     override suspend fun setUserLocation(userLocationModel: UserLocationModel): Result<Unit> {
         return withContext(scope.coroutineContext) {
-            val result = kotlin.runCatching {
+            val result = runCatching {
                 val res = fireStore
                     .collection("UserLocation")
                     .document(userLocationModel.id)
@@ -161,7 +161,7 @@ class DefaultFirebaseDataSource @Inject constructor(
         callbackFlow {
             var documentReference: DocumentReference? = null
 
-            kotlin.runCatching {
+            runCatching {
                 documentReference = fireStore
                     .collection("UserLocation")
                     .document(gameToken)
@@ -176,7 +176,7 @@ class DefaultFirebaseDataSource @Inject constructor(
                     return@addSnapshotListener
                 }
 
-                kotlin.runCatching {
+                runCatching {
                     val result = value.toObject(UserHpDocument::class.java)
                     result?.let {
                         trySend(Result.success(it.asDomain()))
@@ -191,7 +191,7 @@ class DefaultFirebaseDataSource @Inject constructor(
 
     override suspend fun setUserHp(gameToken: String, userHpModel: UserHpModel): Result<Unit> {
         return withContext(scope.coroutineContext) {
-            val result = kotlin.runCatching {
+            val result = runCatching {
                 val res = fireStore
                     .collection("UserLocation")
                     .document(gameToken)
@@ -209,7 +209,7 @@ class DefaultFirebaseDataSource @Inject constructor(
 
     override suspend fun addPlayer(code: String, user: UserModel): Result<Unit> {
         return withContext(scope.coroutineContext) {
-            val result = kotlin.runCatching {
+            val result = runCatching {
                 val res = fireStore
                     .collection("Promises")
                     .document(code)

--- a/firebase/src/main/kotlin/com/woory/firebase/mapper/UserHpMapper.kt
+++ b/firebase/src/main/kotlin/com/woory/firebase/mapper/UserHpMapper.kt
@@ -19,13 +19,3 @@ object UserHpMapper : ModelMapper<UserHpModel, UserHpDocument> {
 internal fun UserHpModel.asModel() = UserHpMapper.asModel(this)
 
 internal fun UserHpDocument.asDomain() = UserHpMapper.asDomain(this)
-
-//internal fun UserHpDocument.asUserHpModel() = UserHpModel(
-//    id = this.id,
-//    hp = this.hp
-//)
-//
-//internal fun UserHpModel.asUserHp() = UserHpDocument(
-//    id = this.id,
-//    hp = this.hp
-//)

--- a/firebase/src/main/kotlin/com/woory/firebase/mapper/UserLocationMapper.kt
+++ b/firebase/src/main/kotlin/com/woory/firebase/mapper/UserLocationMapper.kt
@@ -20,13 +20,3 @@ object UserLocationMapper : ModelMapper<UserLocationModel, UserLocationDocument>
 internal fun UserLocationModel.asModel() = UserLocationMapper.asModel(this)
 
 internal fun UserLocationDocument.asDomain() = UserLocationMapper.asDomain(this)
-
-//internal fun UserLocationDocument.asUserLocationModel() = UserLocationModel(
-//    id = this.id,
-//    location = GeoPointModel(this.location.latitude, this.location.longitude)
-//)
-//
-//internal fun UserLocationModel.asUserLocation() = UserLocationDocument(
-//    id = this.id,
-//    location = GeoPoint(this.location.latitude, this.location.longitude)
-//)

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -41,10 +41,10 @@
         <activity
             android:name=".ui.join.ProfileActivity"
             android:exported="false"
-            android:parentActivityName=".ui.main.MainActivity"
             android:launchMode="singleTop" />
         <activity
             android:name=".ui.join.JoinActivity"
+            android:parentActivityName=".ui.main.MainActivity"
             android:exported="false" />
 
         <receiver android:name=".background.alarm.AlarmReceiver" />

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -7,15 +7,19 @@
     <application>
         <activity
             android:name=".ui.promises.PromisesActivity"
+            android:parentActivityName=".ui.main.MainActivity"
             android:exported="false" />
         <activity
             android:name=".ui.gameresult.GameResultActivity"
+            android:parentActivityName=".ui.main.MainActivity"
             android:exported="false" />
         <activity
             android:name=".ui.gaming.GamingActivity"
+            android:parentActivityName=".ui.main.MainActivity"
             android:exported="false" />
         <activity
             android:name=".ui.promiseinfo.PromiseInfoActivity"
+            android:parentActivityName=".ui.main.MainActivity"
             android:exported="false" />
         <activity
             android:name=".ui.splash.SplashActivity"
@@ -32,10 +36,12 @@
             android:exported="false" />
         <activity
             android:name=".ui.creatingpromise.CreatingPromiseActivity"
+            android:parentActivityName=".ui.main.MainActivity"
             android:exported="false" />
         <activity
             android:name=".ui.join.ProfileActivity"
             android:exported="false"
+            android:parentActivityName=".ui.main.MainActivity"
             android:launchMode="singleTop" />
         <activity
             android:name=".ui.join.JoinActivity"

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/LocationSearchResultFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/LocationSearchResultFragment.kt
@@ -41,6 +41,10 @@ class LocationSearchResultFragment :
                 }
             }
         }
+
+        binding.btnSubmitSearch.setOnClickListener {
+            findLocation(binding.svPromiseLocation.query.toString())
+        }
     }
 
     private fun setSearchedLocation(location: LocationSearchResult) {

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
@@ -55,11 +55,12 @@ class PromiseInfoFragment :
 
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.uiState.collect {
-                    if (it is PromiseUiState.Fail) {
-                        makeSnackBar(it.message)
-                        viewModel.setUiState(PromiseUiState.Waiting)
-                    }
+                viewModel.errorState.collect {
+                    val errorMessage =
+                        it.message ?: requireContext().resources.getString(R.string.unknown_error)
+                    makeSnackBar(
+                        "Error : $errorMessage"
+                    )
                 }
             }
         }
@@ -88,8 +89,8 @@ class PromiseInfoFragment :
                                     it.data.promiseLocation.geoPoint.latitude,
                                     it.data.promiseLocation.geoPoint.longitude
                                 )
+                                participantAdapter.submitList(it.data.users)
                             }
-                            participantAdapter.submitList(it?.data?.users)
                         }
                     }
                 }
@@ -104,7 +105,7 @@ class PromiseInfoFragment :
             zoomLevel = 15
 
             val marker = TMapMarkerItem().apply {
-                id = "promiseLocation"
+                id = PROMISE_LOCATION_MARKER_ID
                 icon = markerImage
                 tMapPoint = TMapPoint(latitude, longitude)
             }
@@ -116,5 +117,9 @@ class PromiseInfoFragment :
 
     private fun makeSnackBar(text: String) {
         Snackbar.make(binding.root, text, Snackbar.LENGTH_SHORT).show()
+    }
+
+    companion object {
+        private const val PROMISE_LOCATION_MARKER_ID = "promiseLocation"
     }
 }

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
@@ -37,7 +37,6 @@ class PromiseInfoFragment :
         setUpMapView()
         viewModel.fetchPromiseDate()
         binding.apply {
-            lifecycleOwner = viewLifecycleOwner
             vm = viewModel
             defaultString = ""
         }
@@ -48,11 +47,7 @@ class PromiseInfoFragment :
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.errorState.collect {
                 if (it) {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.promise_fetch_fail),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    makeSnackBar(getString(R.string.promise_fetch_fail))
                     viewModel.setUiState(PromiseUiState.Loading)
                     viewModel.setErrorState(false)
                 }

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
@@ -5,10 +5,16 @@ import android.content.ClipboardManager
 import android.content.Context.CLIPBOARD_SERVICE
 import android.os.Bundle
 import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.snackbar.Snackbar
+import com.skt.tmap.TMapPoint
 import com.skt.tmap.TMapView
+import com.skt.tmap.overlay.TMapMarkerItem
 import com.woory.presentation.R
 import com.woory.presentation.databinding.FragmentPromiseInfoBinding
 import com.woory.presentation.ui.BaseFragment
@@ -31,29 +37,35 @@ class PromiseInfoFragment :
         requireContext().getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
     }
 
+    private val markerImage by lazy {
+        ContextCompat.getDrawable(requireActivity(), R.drawable.bg_speech_bubble)?.toBitmap()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         setUpMapView()
+        setUpButtonListener()
+
         viewModel.fetchPromiseDate()
         binding.apply {
             vm = viewModel
             defaultString = ""
         }
 
-        binding.rvPromiseParticipant.adapter = participantAdapter
-        participantAdapter.submitList(viewModel.dummyUsers)
-
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.errorState.collect {
-                if (it) {
-                    makeSnackBar(getString(R.string.promise_fetch_fail))
-                    viewModel.setUiState(PromiseUiState.Loading)
-                    viewModel.setErrorState(false)
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect {
+                    if (it is PromiseUiState.Fail) {
+                        makeSnackBar(it.message)
+                        viewModel.setUiState(PromiseUiState.Waiting)
+                    }
                 }
             }
         }
+    }
 
+    private fun setUpButtonListener() {
         binding.btnCodeCopy.setOnClickListener {
             val clip = ClipData.newPlainText("", viewModel.gameCode.value)
             clipBoard.setPrimaryClip(clip)
@@ -64,8 +76,42 @@ class PromiseInfoFragment :
     private fun setUpMapView() {
         mapView = TMapView(getActivityContext(requireContext())).apply {
             setSKTMapApiKey(MAP_API_KEY)
+
+            setOnMapReadyListener {
+                binding.rvPromiseParticipant.adapter = participantAdapter
+                viewLifecycleOwner.lifecycleScope.launch {
+                    repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        viewModel.promiseModel.collect {
+                            if (it != null) {
+                                setMapItem(
+                                    this@apply,
+                                    it.data.promiseLocation.geoPoint.latitude,
+                                    it.data.promiseLocation.geoPoint.longitude
+                                )
+                            }
+                            participantAdapter.submitList(it?.data?.users)
+                        }
+                    }
+                }
+            }
         }
         binding.containerMap.addView(mapView)
+    }
+
+    private fun setMapItem(tMapView: TMapView, latitude: Double, longitude: Double) {
+        tMapView.apply {
+            setCenterPoint(latitude, longitude)
+            zoomLevel = 15
+
+            val marker = TMapMarkerItem().apply {
+                id = "promiseLocation"
+                icon = markerImage
+                tMapPoint = TMapPoint(latitude, longitude)
+            }
+
+            removeAllTMapMarkerItem()
+            addTMapMarkerItem(marker)
+        }
     }
 
     private fun makeSnackBar(text: String) {

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoViewModel.kt
@@ -53,9 +53,6 @@ class PromiseInfoViewModel @Inject constructor(
 
             repository.getPromiseByCodeAndListen(code).collect {
                 it.onSuccess {
-                    it.data.users.forEach {
-                        Timber.tag("123123").d(it.data.profileImage.toString())
-                    }
                     val promiseModel = PromiseMapper.asUiModel(it)
                     _uiState.emit(PromiseUiState.Success)
                     _promiseModel.emit(promiseModel)

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoViewModel.kt
@@ -1,13 +1,9 @@
 package com.woory.presentation.ui.promiseinfo
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woory.data.repository.PromiseRepository
 import com.woory.presentation.model.Promise
-import com.woory.presentation.model.User
-import com.woory.presentation.model.UserData
-import com.woory.presentation.model.UserProfileImage
 import com.woory.presentation.model.mapper.promise.PromiseMapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,15 +19,9 @@ class PromiseInfoViewModel @Inject constructor(
     private val _gameCode: MutableStateFlow<String> = MutableStateFlow("")
     val gameCode: StateFlow<String> = _gameCode.asStateFlow()
 
-    private val _isMapReady: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isMapReady: StateFlow<Boolean> = _isMapReady.asStateFlow()
-
     private val _uiState: MutableStateFlow<PromiseUiState> =
         MutableStateFlow(PromiseUiState.Waiting)
     val uiState: StateFlow<PromiseUiState> = _uiState.asStateFlow()
-
-    private val _errorState: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val errorState: StateFlow<Boolean> = _errorState.asStateFlow()
 
     private val _promiseModel: MutableStateFlow<Promise?> = MutableStateFlow(null)
     val promiseModel: StateFlow<Promise?> = _promiseModel.asStateFlow()
@@ -39,34 +29,15 @@ class PromiseInfoViewModel @Inject constructor(
     private val _host: MutableStateFlow<String> = MutableStateFlow("")
     private val host: StateFlow<String> = _host.asStateFlow()
 
-    val dummyUsers = listOf(
-        User("testCode", UserData("조재우", UserProfileImage("#FF0000", 0))),
-        User("testCode2", UserData("전도명", UserProfileImage("#00FF00", 1))),
-        User("testCode3", UserData("이수진", UserProfileImage("#0000FF", 2))),
-        User("testCode4", UserData("유호현", UserProfileImage("#FF00FF", 3)))
-    )
-
     fun setGameCode(code: String) {
         viewModelScope.launch {
             _gameCode.emit(code)
         }
     }
 
-    fun setMapReady(isMapReady: Boolean) {
-        viewModelScope.launch {
-            _isMapReady.emit(isMapReady)
-        }
-    }
-
     fun setUiState(state: PromiseUiState) {
         viewModelScope.launch {
             _uiState.emit(state)
-        }
-    }
-
-    fun setErrorState(boolean: Boolean) {
-        viewModelScope.launch {
-            _errorState.emit(boolean)
         }
     }
 
@@ -78,14 +49,22 @@ class PromiseInfoViewModel @Inject constructor(
         viewModelScope.launch {
             val code = gameCode.value
             _uiState.emit(PromiseUiState.Loading)
-            repository.getPromiseByCode(code).onSuccess {
-                val promiseModel = PromiseMapper.asUiModel(it)
-                _promiseModel.emit(promiseModel)
-                _uiState.emit(PromiseUiState.Success)
-                _host.emit(promiseModel.data.host.userId)
-            }.onFailure {
-                setErrorState(true)
+
+            repository.getPromiseByCodeAndListen(code).collect {
+                it.onSuccess {
+                    val promiseModel = PromiseMapper.asUiModel(it)
+                    _uiState.emit(PromiseUiState.Success)
+                    _promiseModel.emit(promiseModel)
+                    _host.emit(promiseModel.data.host.userId)
+                }
+                it.onFailure { error ->
+                    setUiState(PromiseUiState.Fail(error.message ?: DEFAULT_ERROR_MESSAGE))
+                }
             }
         }
+    }
+
+    companion object {
+        private const val DEFAULT_ERROR_MESSAGE = ""
     }
 }

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -52,6 +53,9 @@ class PromiseInfoViewModel @Inject constructor(
 
             repository.getPromiseByCodeAndListen(code).collect {
                 it.onSuccess {
+                    it.data.users.forEach {
+                        Timber.tag("123123").d(it.data.profileImage.toString())
+                    }
                     val promiseModel = PromiseMapper.asUiModel(it)
                     _uiState.emit(PromiseUiState.Success)
                     _promiseModel.emit(promiseModel)

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseUiState.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseUiState.kt
@@ -3,6 +3,5 @@ package com.woory.presentation.ui.promiseinfo
 sealed class PromiseUiState {
     object Loading : PromiseUiState()
     object Success : PromiseUiState()
-    data class Fail(val message: String) : PromiseUiState()
-    object Waiting : PromiseUiState()
+    object Fail : PromiseUiState()
 }

--- a/presentation/src/main/res/drawable/ic_refresh.xml
+++ b/presentation/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/presentation/src/main/res/layout/fragment_location_search_result.xml
+++ b/presentation/src/main/res/layout/fragment_location_search_result.xml
@@ -28,7 +28,9 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_search_result"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             android:layout_height="wrap_content"
             android:layout_margin="10dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"

--- a/presentation/src/main/res/layout/fragment_promise_info.xml
+++ b/presentation/src/main/res/layout/fragment_promise_info.xml
@@ -29,11 +29,22 @@
             tools:context=".ui.promiseinfo.PromiseInfoFragment">
 
             <ProgressBar
-                android:id="@+id/loadingIndicator"
+                android:id="@+id/ic_loading"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:indeterminateTint="@color/loading_indicator_color"
                 android:visibility="@{vm.uiState instanceof PromiseUiState.Loading ? View.VISIBLE : View.GONE}"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/iv_refresh"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_refresh"
+                android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.VISIBLE : View.GONE}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -51,6 +62,7 @@
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 app:layout_constraintBottom_toBottomOf="@id/guideline_center"
+                android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -62,6 +74,7 @@
                 android:layout_margin="20dp"
                 android:textSize="24sp"
                 android:text="@{vm.promiseModel.code}"
+                android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
                 android:textStyle="italic|bold"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="@id/guideline_center" />
@@ -73,6 +86,7 @@
                 android:layout_marginHorizontal="10dp"
                 android:text="@string/code_copy"
                 android:textSize="18sp"
+                android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
                 app:layout_constraintEnd_toStartOf="@id/btn_code_share"
                 app:layout_constraintTop_toTopOf="@id/btn_code_share" />
 
@@ -83,6 +97,7 @@
                 android:layout_marginHorizontal="10dp"
                 android:layout_marginTop="10dp"
                 android:text="@string/code_share"
+                android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
                 android:textSize="18sp"
                 app:layout_constraintBottom_toBottomOf="@id/btn_code_copy"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -94,6 +109,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_margin="20dp"
+                android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/tv_promise_code">
@@ -185,6 +201,7 @@
                 android:layout_margin="20dp"
                 android:text="@string/participant"
                 android:textSize="32sp"
+                android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/cv_promise_info" />
 
@@ -194,6 +211,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
                 android:orientation="horizontal"
+                android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toBottomOf="@id/tv_participant" />

--- a/presentation/src/main/res/layout/fragment_promise_info.xml
+++ b/presentation/src/main/res/layout/fragment_promise_info.xml
@@ -25,6 +25,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:backgroundTint="@{vm.uiState instanceof PromiseUiState.Loading ? @color/loading_indicator_color : @color/white}"
             tools:context=".ui.promiseinfo.PromiseInfoFragment">
 
             <ProgressBar

--- a/presentation/src/main/res/layout/item_promise_user.xml
+++ b/presentation/src/main/res/layout/item_promise_user.xml
@@ -8,10 +8,6 @@
             name="item"
             type="com.woory.presentation.model.User" />
 
-        <variable
-            name="vm"
-            type="com.woory.presentation.ui.promiseinfo.PromiseInfoViewModel" />
-
         <import type="android.graphics.Color" />
 
         <import type="com.woory.presentation.model.ProfileImage" />

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -77,4 +77,5 @@
     <string name="notification_channel_promise_start_description">게임 시작시 게임 진행 알림을 받는 채널입니다.</string>
     <string name="notification_start_title">게임이 진행중 입니다.</string>
     <string name="notification_start_content">자기장을 피해 약속 장소로 이동하세요.</string>
+    <string name="unknown_error" />
 </resources>


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#27 
- resolved boostcampwm-2022/android11-almost-there#41 

## 작업 내용 요약

- 뒤로가기 버튼을 누르면 Main화면으로 이동하도록 구현
- 약속 상세화면에서 참여자 정보가 실시간으로 업데이트 되도록 수정
- 약속 참여하기를 하면 오류가 나는 부분 수정

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?