### PR TITLE
재부팅 시 AlarmManager 알람 재등록 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".AlmostThereApp"

--- a/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
@@ -16,7 +16,7 @@ class DefaultPromiseRepository @Inject constructor(
     override suspend fun setPromise(promiseDataModel: PromiseDataModel): Result<String> {
         val result = firebaseDataSource.setPromise(promiseDataModel)
             .onSuccess { code ->
-                setPromiseAlarm(PromiseModel(code, promiseDataModel))
+                setPromiseAlarmByPromiseModel(PromiseModel(code, promiseDataModel))
             }
             .onFailure {
                 return Result.failure(it)
@@ -27,8 +27,11 @@ class DefaultPromiseRepository @Inject constructor(
     override suspend fun getPromiseAlarm(promiseCode: String): Result<PromiseAlarmModel> =
         databaseDataSource.getPromiseAlarmWhereCode(promiseCode)
 
-    override suspend fun setPromiseAlarm(promiseModel: PromiseModel): Result<Unit> =
-        databaseDataSource.setPromiseAlarm(promiseModel)
+    override suspend fun setPromiseAlarmByPromiseModel(promiseModel: PromiseModel): Result<Unit> =
+        databaseDataSource.setPromiseAlarmByPromiseModel(promiseModel)
+
+    override suspend fun setPromiseAlarmByPromiseAlarmModel(promiseAlarmModel: PromiseAlarmModel): Result<Unit> =
+        databaseDataSource.setPromiseAlarmByPromiseAlarmModel(promiseAlarmModel)
 
     override suspend fun getAddressByPoint(geoPointModel: GeoPointModel): Result<String> =
         networkDataSource.getAddressByPoint(geoPointModel)

--- a/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
@@ -27,6 +27,9 @@ class DefaultPromiseRepository @Inject constructor(
     override suspend fun getPromiseAlarm(promiseCode: String): Result<PromiseAlarmModel> =
         databaseDataSource.getPromiseAlarmWhereCode(promiseCode)
 
+    override suspend fun getAllPromiseAlarms(): Result<List<PromiseAlarmModel>> =
+        databaseDataSource.getAll()
+
     override suspend fun setPromiseAlarmByPromiseModel(promiseModel: PromiseModel): Result<Unit> =
         databaseDataSource.setPromiseAlarmByPromiseModel(promiseModel)
 

--- a/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
@@ -25,6 +25,8 @@ interface PromiseRepository {
 
     suspend fun getPromiseAlarm(promiseCode: String): Result<PromiseAlarmModel>
 
+    suspend fun getAllPromiseAlarms(): Result<List<PromiseAlarmModel>>
+
     suspend fun setPromiseAlarmByPromiseModel(promiseModel: PromiseModel): Result<Unit>
 
     suspend fun setPromiseAlarmByPromiseAlarmModel(promiseAlarmModel: PromiseAlarmModel): Result<Unit>

--- a/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
@@ -23,7 +23,9 @@ interface PromiseRepository {
 
     suspend fun getPromiseAlarm(promiseCode: String): Result<PromiseAlarmModel>
 
-    suspend fun setPromiseAlarm(promiseModel: PromiseModel): Result<Unit>
+    suspend fun setPromiseAlarmByPromiseModel(promiseModel: PromiseModel): Result<Unit>
+
+    suspend fun setPromiseAlarmByPromiseAlarmModel(promiseAlarmModel: PromiseAlarmModel): Result<Unit>
 
     suspend fun getSearchedLocationByKeyword(keyword: String): Result<List<LocationSearchModel>>
 }

--- a/data/src/main/kotlin/com/woory/data/source/DatabaseDataSource.kt
+++ b/data/src/main/kotlin/com/woory/data/source/DatabaseDataSource.kt
@@ -4,7 +4,9 @@ import com.woory.data.model.PromiseAlarmModel
 import com.woory.data.model.PromiseModel
 
 interface DatabaseDataSource {
-    suspend fun setPromiseAlarm(promiseModel: PromiseModel): Result<Unit>
+    suspend fun setPromiseAlarmByPromiseModel(promiseModel: PromiseModel): Result<Unit>
+
+    suspend fun setPromiseAlarmByPromiseAlarmModel(promiseAlarmModel: PromiseAlarmModel): Result<Unit>
 
     suspend fun getAll(): Result<List<PromiseAlarmModel>>
 

--- a/database/src/main/kotlin/com/woory/database/OffsetDateTimeConverters.kt
+++ b/database/src/main/kotlin/com/woory/database/OffsetDateTimeConverters.kt
@@ -1,23 +1,23 @@
 package com.woory.database
 
 import androidx.room.TypeConverter
+import org.threeten.bp.Instant
 import org.threeten.bp.OffsetDateTime
+import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
 
 object OffsetDateTimeConverters {
     private val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
     @TypeConverter
-    @JvmStatic
-    fun toOffsetDateTime(value: String?): OffsetDateTime? {
+    fun toOffsetDateTime(value: Long?): OffsetDateTime? {
         return value?.let {
-            return formatter.parse(value, OffsetDateTime::from)
+            return OffsetDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneId.systemDefault())
         }
     }
 
     @TypeConverter
-    @JvmStatic
-    fun fromOffsetDateTime(date: OffsetDateTime?): String? {
-        return date?.format(formatter)
+    fun fromOffsetDateTime(date: OffsetDateTime?): Long? {
+        return date?.toInstant()?.toEpochMilli()
     }
 }

--- a/database/src/main/kotlin/com/woory/database/PromiseAlarmDao.kt
+++ b/database/src/main/kotlin/com/woory/database/PromiseAlarmDao.kt
@@ -14,7 +14,7 @@ interface PromiseAlarmDao {
     suspend fun setPromiseAlarm(gameTimeEntity: PromiseAlarmEntity)
 
     @Query("SELECT * FROM promise_alarm WHERE end_time > :currentTime")
-    suspend fun getAll(currentTime: OffsetDateTime = OffsetDateTime.now()): List<PromiseAlarmEntity>
+    suspend fun getAll(currentTime: Long = OffsetDateTime.now().toInstant().toEpochMilli()): List<PromiseAlarmEntity>
 
     @Query("SELECT * From promise_alarm ORDER BY datetime(start_time)")
     suspend fun getPromiseAlarmSortedByStartTime(): List<PromiseAlarmEntity>

--- a/database/src/main/kotlin/com/woory/database/PromiseAlarmDao.kt
+++ b/database/src/main/kotlin/com/woory/database/PromiseAlarmDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.woory.database.entity.PromiseAlarmEntity
+import org.threeten.bp.OffsetDateTime
 
 @Dao
 interface PromiseAlarmDao {
@@ -12,8 +13,8 @@ interface PromiseAlarmDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun setPromiseAlarm(gameTimeEntity: PromiseAlarmEntity)
 
-    @Query("SELECT * FROM promise_alarm")
-    suspend fun getAll(): List<PromiseAlarmEntity>
+    @Query("SELECT * FROM promise_alarm WHERE end_time > :currentTime")
+    suspend fun getAll(currentTime: OffsetDateTime = OffsetDateTime.now()): List<PromiseAlarmEntity>
 
     @Query("SELECT * From promise_alarm ORDER BY datetime(start_time)")
     suspend fun getPromiseAlarmSortedByStartTime(): List<PromiseAlarmEntity>

--- a/database/src/main/kotlin/com/woory/database/datasource/DefaultDatabaseDataSource.kt
+++ b/database/src/main/kotlin/com/woory/database/datasource/DefaultDatabaseDataSource.kt
@@ -4,38 +4,44 @@ import com.woory.data.model.PromiseAlarmModel
 import com.woory.data.model.PromiseModel
 import com.woory.data.source.DatabaseDataSource
 import com.woory.database.PromiseAlarmDao
-import com.woory.database.mapper.toPromiseAlarmEntity
-import com.woory.database.mapper.toPromiseAlarmModel
+import com.woory.database.mapper.asPromiseAlarmEntity
+import com.woory.database.mapper.asPromiseAlarmModel
 
 class DefaultDatabaseDataSource(private val dao: PromiseAlarmDao) : DatabaseDataSource {
 
-    override suspend fun setPromiseAlarm(promiseModel: PromiseModel): Result<Unit> {
+    override suspend fun setPromiseAlarmByPromiseModel(promiseModel: PromiseModel): Result<Unit> {
         return runCatching {
-            dao.setPromiseAlarm(promiseModel.toPromiseAlarmEntity())
+            dao.setPromiseAlarm(promiseModel.asPromiseAlarmEntity())
+        }
+    }
+
+    override suspend fun setPromiseAlarmByPromiseAlarmModel(promiseAlarmModel: PromiseAlarmModel): Result<Unit> {
+        return kotlin.runCatching {
+            dao.setPromiseAlarm(promiseAlarmModel.asPromiseAlarmEntity())
         }
     }
 
     override suspend fun getAll(): Result<List<PromiseAlarmModel>> {
         return runCatching {
-            dao.getAll().toPromiseAlarmModel()
+            dao.getAll().asPromiseAlarmModel()
         }
     }
 
     override suspend fun getPromiseAlarmSortedByStartTime(): Result<List<PromiseAlarmModel>> {
         return runCatching {
-            dao.getPromiseAlarmSortedByStartTime().toPromiseAlarmModel()
+            dao.getPromiseAlarmSortedByStartTime().asPromiseAlarmModel()
         }
     }
 
     override suspend fun getPromiseAlarmSortedByEndTime(): Result<List<PromiseAlarmModel>> {
         return runCatching {
-            dao.getPromiseAlarmSortedByEndTime().toPromiseAlarmModel()
+            dao.getPromiseAlarmSortedByEndTime().asPromiseAlarmModel()
         }
     }
 
     override suspend fun getPromiseAlarmWhereCode(promiseCode: String): Result<PromiseAlarmModel> {
         return runCatching {
-            dao.getPromiseAlarmWhereCode(promiseCode).toPromiseAlarmModel()
+            dao.getPromiseAlarmWhereCode(promiseCode).asPromiseAlarmModel()
         }
     }
 }

--- a/database/src/main/kotlin/com/woory/database/mapper/PromiseAlarmMapper.kt
+++ b/database/src/main/kotlin/com/woory/database/mapper/PromiseAlarmMapper.kt
@@ -4,7 +4,7 @@ import com.woory.data.model.PromiseAlarmModel
 import com.woory.data.model.PromiseModel
 import com.woory.database.entity.PromiseAlarmEntity
 
-fun PromiseModel.toPromiseAlarmEntity() =
+fun PromiseModel.asPromiseAlarmEntity() =
     PromiseAlarmEntity(
         promiseCode = code,
         status = "READY",
@@ -12,7 +12,7 @@ fun PromiseModel.toPromiseAlarmEntity() =
         endTime = data.promiseDateTime,
     )
 
-fun PromiseAlarmEntity.toPromiseAlarmModel() =
+fun PromiseAlarmEntity.asPromiseAlarmModel() =
     PromiseAlarmModel(
         alarmCode = alarmCode,
         promiseCode = promiseCode,
@@ -21,7 +21,16 @@ fun PromiseAlarmEntity.toPromiseAlarmModel() =
         endTime = endTime
     )
 
-fun List<PromiseAlarmEntity>.toPromiseAlarmModel() =
+fun PromiseAlarmModel.asPromiseAlarmEntity() =
+    PromiseAlarmEntity(
+        alarmCode = alarmCode,
+        promiseCode = promiseCode,
+        status = status,
+        startTime = startTime,
+        endTime = endTime
+    )
+
+fun List<PromiseAlarmEntity>.asPromiseAlarmModel() =
     map {
-        it.toPromiseAlarmModel()
+        it.asPromiseAlarmModel()
     }

--- a/firebase/src/main/kotlin/com/woory/firebase/mapper/PromiseDataMapper.kt
+++ b/firebase/src/main/kotlin/com/woory/firebase/mapper/PromiseDataMapper.kt
@@ -3,8 +3,8 @@ package com.woory.firebase.mapper
 import com.google.firebase.firestore.GeoPoint
 import com.woory.data.model.*
 import com.woory.firebase.model.PromiseDocument
-import com.woory.firebase.util.asOffsetDate
-import com.woory.firebase.util.asTimeStamp
+import com.woory.firebase.util.TimeConverter.asOffsetDate
+import com.woory.firebase.util.TimeConverter.asTimeStamp
 
 internal fun PromiseDocument.asDomain(): PromiseModel {
     val promiseLocation = LocationModel(

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -49,6 +49,14 @@
 
         <receiver android:name=".background.alarm.AlarmReceiver" />
         <receiver android:name=".background.alarm.AlarmTouchReceiver" />
+        <receiver
+            android:name=".background.alarm.AlarmRestartReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <service
             android:name=".background.service.PromiseGameService"

--- a/presentation/src/main/kotlin/com/woory/presentation/background/HiltBroadcastReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/HiltBroadcastReceiver.kt
@@ -1,0 +1,12 @@
+package com.woory.presentation.background
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.annotation.CallSuper
+
+abstract class HiltBroadcastReceiver : BroadcastReceiver() {
+
+    @CallSuper
+    override fun onReceive(p0: Context?, p1: Intent?) { }
+}

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmFunctions.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmFunctions.kt
@@ -28,17 +28,11 @@ class AlarmFunctions(private val context: Context) {
             putPromiseAlarm(promiseAlarm)
         }
 
-        val pendingIntentFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_IMMUTABLE
-        } else {
-            PendingIntent.FLAG_UPDATE_CURRENT
-        }
-
         val pendingIntent = PendingIntent.getBroadcast(
             context,
             promiseAlarm.alarmCode,
             receiverIntent,
-            pendingIntentFlag
+            PendingIntent.FLAG_IMMUTABLE
         )
 
         alarmManager?.setExactAndAllowWhileIdle(
@@ -59,7 +53,7 @@ class AlarmFunctions(private val context: Context) {
                 context,
                 alarmCode,
                 intent,
-                PendingIntent.FLAG_UPDATE_CURRENT
+                PendingIntent.FLAG_IMMUTABLE
             )
         }
 

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
@@ -53,11 +53,12 @@ class AlarmReceiver : HiltBroadcastReceiver() {
         }
 
         CoroutineScope(Dispatchers.IO).launch {
-            repository.setPromiseAlarmByPromiseAlarmModel(
-                promiseAlarm
-                    .copy(state = AlarmState.END)
-                    .asDomain()
-            )
+            val alarmFunctions = AlarmFunctions(context)
+
+            promiseAlarm.copy(state = AlarmState.END).run {
+                alarmFunctions.registerAlarm(this)
+                repository.setPromiseAlarmByPromiseAlarmModel(this.asDomain())
+            }
         }
 
         Intent(context, PromiseGameService::class.java).run {

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
@@ -1,6 +1,5 @@
 package com.woory.presentation.background.alarm
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -9,7 +8,6 @@ import com.woory.data.repository.PromiseRepository
 import com.woory.presentation.background.notification.NotificationProvider
 import com.woory.presentation.R
 import com.woory.presentation.background.HiltBroadcastReceiver
-import com.woory.presentation.background.notification.NotificationProvider
 import com.woory.presentation.background.service.PromiseGameService
 import com.woory.presentation.background.util.asPromiseAlarm
 import com.woory.presentation.background.util.putPromiseAlarm

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
@@ -1,6 +1,5 @@
 package com.woory.presentation.background.alarm
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -24,8 +23,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class AlarmReceiver : HiltBroadcastReceiver() {
 
-    @Inject
-    lateinit var repository: PromiseRepository
+    @Inject lateinit var repository: PromiseRepository
+    private val coroutineScope by lazy { CoroutineScope(Dispatchers.IO) }
 
     override fun onReceive(context: Context?, intent: Intent?) {
         super.onReceive(context, intent)
@@ -52,7 +51,7 @@ class AlarmReceiver : HiltBroadcastReceiver() {
             NotificationChannelProvider.providePromiseStartChannel(context)
         }
 
-        CoroutineScope(Dispatchers.IO).launch {
+        coroutineScope.launch {
             val alarmFunctions = AlarmFunctions(context)
 
             promiseAlarm.copy(state = AlarmState.END).run {

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmRestartReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmRestartReceiver.kt
@@ -1,0 +1,43 @@
+package com.woory.presentation.background.alarm
+
+import android.content.Context
+import android.content.Intent
+import com.woory.data.repository.PromiseRepository
+import com.woory.presentation.background.HiltBroadcastReceiver
+import com.woory.presentation.model.mapper.alarm.asUiModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class AlarmRestartReceiver : HiltBroadcastReceiver() {
+
+    @Inject
+    lateinit var repository: PromiseRepository
+    private val coroutineScope by lazy { CoroutineScope(Dispatchers.IO) }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        super.onReceive(context, intent)
+        context ?: throw IllegalArgumentException("is context null")
+        intent ?: throw IllegalArgumentException("is intent null")
+
+
+        if (intent.action.equals(Intent.ACTION_BOOT_COMPLETED)) {
+            val alarmFunctions = AlarmFunctions(context)
+            coroutineScope.launch {
+                repository.getAllPromiseAlarms()
+                    .onSuccess { promiseAlarmModels ->
+                        promiseAlarmModels.forEach { promiseAlarmModel ->
+                            alarmFunctions.registerAlarm(promiseAlarmModel.asUiModel())
+                        }
+                    }
+                    .onFailure {
+                        Timber.tag("TAG").d("Error -> $it")
+                    }
+            }
+        }
+    }
+}

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmTouchReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmTouchReceiver.kt
@@ -20,6 +20,7 @@ import javax.inject.Inject
 class AlarmTouchReceiver : HiltBroadcastReceiver() {
 
     @Inject lateinit var repository: PromiseRepository
+    private val coroutineScope by lazy { CoroutineScope(Dispatchers.IO) }
 
     override fun onReceive(context: Context?, intent: Intent?) {
         super.onReceive(context, intent)
@@ -45,7 +46,7 @@ class AlarmTouchReceiver : HiltBroadcastReceiver() {
         context: Context,
         promiseAlarm: PromiseAlarm
     ) {
-        CoroutineScope(Dispatchers.IO).launch {
+        coroutineScope.launch {
             val alarmFunctions = AlarmFunctions(context)
             promiseAlarm.copy(state = AlarmState.START).run {
                 alarmFunctions.registerAlarm(this)

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmTouchReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmTouchReceiver.kt
@@ -1,19 +1,28 @@
 package com.woory.presentation.background.alarm
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.woory.data.repository.PromiseRepository
+import com.woory.presentation.background.HiltBroadcastReceiver
 import com.woory.presentation.background.util.asPromiseAlarm
 import com.woory.presentation.model.AlarmState
 import com.woory.presentation.model.PromiseAlarm
+import com.woory.presentation.model.mapper.alarm.asDomain
 import com.woory.presentation.ui.promiseinfo.PromiseInfoActivity
 import com.woory.presentation.util.PROMISE_CODE_KEY
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
-class AlarmTouchReceiver : BroadcastReceiver() {
+class AlarmTouchReceiver : HiltBroadcastReceiver() {
+
+    @Inject lateinit var repository: PromiseRepository
 
     override fun onReceive(context: Context?, intent: Intent?) {
+        super.onReceive(context, intent)
         context ?: throw IllegalArgumentException("is context null")
         intent ?: throw IllegalArgumentException("is intent null")
 
@@ -36,10 +45,14 @@ class AlarmTouchReceiver : BroadcastReceiver() {
         context: Context,
         promiseAlarm: PromiseAlarm
     ) {
-        val alarmFunctions = AlarmFunctions(context)
-        promiseAlarm.copy(state = AlarmState.START).run {
-            alarmFunctions.registerAlarm(this)
+        CoroutineScope(Dispatchers.IO).launch {
+            val alarmFunctions = AlarmFunctions(context)
+            promiseAlarm.copy(state = AlarmState.START).run {
+                alarmFunctions.registerAlarm(this)
+                repository.setPromiseAlarmByPromiseAlarmModel(this.asDomain())
+            }
         }
+
         val intent = Intent(context, PromiseInfoActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             putExtra(PROMISE_CODE_KEY, promiseAlarm.promiseCode)

--- a/presentation/src/main/kotlin/com/woory/presentation/background/notification/NotificationProvider.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/notification/NotificationProvider.kt
@@ -51,7 +51,7 @@ object NotificationProvider {
             context,
             PROMISE_READY_NOTIFICATION_ID,
             intent,
-            PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_IMMUTABLE
         )
 
         val notification = createNotificationBuilder(

--- a/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseGameService.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseGameService.kt
@@ -20,7 +20,7 @@ class PromiseGameService : Service() {
             this,
             NotificationProvider.PROMISE_START_NOTIFICATION_ID,
             intent,
-            PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_IMMUTABLE
         )
 
         val notification = NotificationProvider.createNotificationBuilder(

--- a/presentation/src/main/kotlin/com/woory/presentation/background/util/Extensions.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/util/Extensions.kt
@@ -1,7 +1,6 @@
 package com.woory.presentation.background.util
 
 import android.content.Intent
-import com.woory.presentation.model.AlarmState
 import com.woory.presentation.model.PromiseAlarm
 import com.woory.presentation.model.asAlarmState
 import org.threeten.bp.Instant
@@ -11,7 +10,7 @@ import org.threeten.bp.ZoneId
 fun Intent.putPromiseAlarm(promiseAlarm: PromiseAlarm) {
     this.putExtra("alarmCode", promiseAlarm.alarmCode)
     this.putExtra("promiseCode", promiseAlarm.promiseCode)
-    this.putExtra("state", promiseAlarm.state.state)
+    this.putExtra("state", promiseAlarm.state.current)
     this.putExtra("startTime", promiseAlarm.startTime.asMillis())
     this.putExtra("endTime", promiseAlarm.endTime.asMillis())
 }

--- a/presentation/src/main/kotlin/com/woory/presentation/model/AlarmState.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/model/AlarmState.kt
@@ -1,6 +1,6 @@
 package com.woory.presentation.model
 
-enum class AlarmState(val state: String) {
+enum class AlarmState(val current: String) {
     READY("READY"), START("START"), END("END")
 }
 

--- a/presentation/src/main/kotlin/com/woory/presentation/model/mapper/alarm/PromiseAlarmMapper.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/model/mapper/alarm/PromiseAlarmMapper.kt
@@ -11,7 +11,7 @@ object PromiseAlarmMapper : UiModelMapper<PromiseAlarm, PromiseAlarmModel> {
         PromiseAlarmModel(
             alarmCode = uiModel.alarmCode,
             promiseCode = uiModel.promiseCode,
-            status = uiModel.state.state,
+            status = uiModel.state.current,
             startTime = uiModel.startTime,
             endTime = uiModel.endTime
         )

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseFragment.kt
@@ -137,6 +137,8 @@ class CreatingPromiseFragment :
                             )
                         )
 
+                        viewModel.setPromiseAlarm(promiseAlarm)
+
                         PromiseInfoActivity.startActivity(
                             requireContext(),
                             promiseAlarm.promiseCode

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woory.data.repository.PromiseRepository
 import com.woory.presentation.model.*
+import com.woory.presentation.model.mapper.alarm.asDomain
 import com.woory.presentation.model.mapper.alarm.asUiModel
 import com.woory.presentation.model.mapper.promise.asDomain
 import com.woory.presentation.model.mapper.searchlocation.SearchResultMapper

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woory.data.repository.PromiseRepository
 import com.woory.presentation.model.*
+import com.woory.presentation.model.mapper.alarm.asDomain
 import com.woory.presentation.model.mapper.alarm.asUiModel
 import com.woory.presentation.model.mapper.promise.asDomain
 import com.woory.presentation.model.mapper.searchlocation.SearchResultMapper
@@ -128,6 +129,12 @@ class CreatingPromiseViewModel @Inject constructor(private val repository: Promi
                     _promiseSettingEvent.emit(promiseAlarm.asUiModel())
                 }
             }
+        }
+    }
+
+    fun setPromiseAlarm(promiseAlarm: PromiseAlarm) {
+        viewModelScope.launch {
+            repository.setPromiseAlarmByPromiseAlarmModel(promiseAlarm.asDomain())
         }
     }
 

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseViewModel.kt
@@ -12,6 +12,7 @@ import com.woory.presentation.model.PromiseData
 import com.woory.presentation.model.User
 import com.woory.presentation.model.UserData
 import com.woory.presentation.model.UserProfileImage
+import com.woory.presentation.model.mapper.alarm.asDomain
 import com.woory.presentation.model.mapper.alarm.asUiModel
 import com.woory.presentation.model.mapper.promise.asDomain
 import com.woory.presentation.model.mapper.searchlocation.SearchResultMapper
@@ -144,6 +145,12 @@ class CreatingPromiseViewModel @Inject constructor(
                     }
                 }
             }
+        }
+    }
+
+    fun setPromiseAlarm(promiseAlarm: PromiseAlarm) {
+        viewModelScope.launch {
+            promiseRepository.setPromiseAlarmByPromiseAlarmModel(promiseAlarm.asDomain())
         }
     }
 

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/join/ProfileViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/join/ProfileViewModel.kt
@@ -74,7 +74,7 @@ class ProfileViewModel @Inject constructor(
         viewModelScope.launch {
             _isLoading.value = true
 
-            promiseRepository.setPromiseAlarm(promise.asDomain())
+            promiseRepository.setPromiseAlarmByPromiseModel(promise.asDomain())
                 .onSuccess {
                     addPlayer(promise.code)
                 }


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#72

## 작업 내용 요약

- 준비 알람 등록시 Room 에 알람 정보 저장
- 준비 알람 터치시 Room에 알람 상태 정보 업데이트
- 게임 시작시 Room에 알람 상태 정보 업데이트
- 부팅 BroadcastReceiver 생성
- 재부팅시 알람 재등록 구현

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?