### PR TITLE
Android12 관련 Notification 수정

### DIFF
--- a/database/src/main/kotlin/com/woory/database/OffsetDateTimeConverters.kt
+++ b/database/src/main/kotlin/com/woory/database/OffsetDateTimeConverters.kt
@@ -1,23 +1,19 @@
 package com.woory.database
 
 import androidx.room.TypeConverter
-import org.threeten.bp.Instant
+import com.woory.database.util.TimeConverter.asMillis
+import com.woory.database.util.TimeConverter.asOffsetDateTime
 import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneId
-import org.threeten.bp.format.DateTimeFormatter
 
 object OffsetDateTimeConverters {
-    private val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
-
     @TypeConverter
     fun toOffsetDateTime(value: Long?): OffsetDateTime? {
-        return value?.let {
-            return OffsetDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneId.systemDefault())
-        }
+        return value?.asOffsetDateTime()
     }
 
     @TypeConverter
     fun fromOffsetDateTime(date: OffsetDateTime?): Long? {
-        return date?.toInstant()?.toEpochMilli()
+        return date?.asMillis()
     }
 }
+

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
@@ -28,8 +28,8 @@ class AlarmReceiver : HiltBroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         super.onReceive(context, intent)
-        context ?: throw IllegalArgumentException("is context null")
-        intent ?: throw IllegalArgumentException("is intent null")
+        context ?: return
+        intent ?: return
 
         val promiseAlarm = intent.asPromiseAlarm()
 

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmReceiver.kt
@@ -79,11 +79,11 @@ class AlarmReceiver : HiltBroadcastReceiver() {
             NotificationChannelProvider.providePromiseReadyChannel(context)
         }
 
-        NotificationProvider.notifyPromiseReadyNotification(
+        NotificationProvider.notifyBroadcastNotification(
             context,
             context.getString(R.string.notification_ready_title),
             context.getString(R.string.notification_ready_content),
-            promiseAlarm
+            promiseAlarm,
         )
     }
 }

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmRestartReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmRestartReceiver.kt
@@ -21,8 +21,8 @@ class AlarmRestartReceiver : HiltBroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         super.onReceive(context, intent)
-        context ?: throw IllegalArgumentException("is context null")
-        intent ?: throw IllegalArgumentException("is intent null")
+        context ?: return
+        intent ?: return
 
 
         if (intent.action.equals(Intent.ACTION_BOOT_COMPLETED)) {

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmTouchReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmTouchReceiver.kt
@@ -3,16 +3,18 @@ package com.woory.presentation.background.alarm
 import android.content.Context
 import android.content.Intent
 import com.woory.data.repository.PromiseRepository
+import com.woory.presentation.R
 import com.woory.presentation.background.HiltBroadcastReceiver
+import com.woory.presentation.background.notification.NotificationProvider
 import com.woory.presentation.background.util.asPromiseAlarm
 import com.woory.presentation.model.AlarmState
 import com.woory.presentation.model.PromiseAlarm
 import com.woory.presentation.model.mapper.alarm.asDomain
 import com.woory.presentation.ui.promiseinfo.PromiseInfoActivity
-import com.woory.presentation.util.PROMISE_CODE_KEY
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -51,14 +53,17 @@ class AlarmTouchReceiver : HiltBroadcastReceiver() {
             promiseAlarm.copy(state = AlarmState.START).run {
                 alarmFunctions.registerAlarm(this)
                 repository.setPromiseAlarmByPromiseAlarmModel(this.asDomain())
+                    .onSuccess {
+                        delay(1000)
+                        NotificationProvider.notifyActivityNotification(
+                            context,
+                            context.getString(R.string.notification_ready_complete_title),
+                            context.getString(R.string.notification_ready_complete_content),
+                            promiseAlarm,
+                            PromiseInfoActivity::class.java,
+                        )
+                    }
             }
         }
-
-        val intent = Intent(context, PromiseInfoActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            putExtra(PROMISE_CODE_KEY, promiseAlarm.promiseCode)
-        }
-
-        context.startActivity(intent)
     }
 }

--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmTouchReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmTouchReceiver.kt
@@ -24,8 +24,8 @@ class AlarmTouchReceiver : HiltBroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         super.onReceive(context, intent)
-        context ?: throw IllegalArgumentException("is context null")
-        intent ?: throw IllegalArgumentException("is intent null")
+        context ?: return
+        intent ?: return
 
         val promiseAlarm = intent.asPromiseAlarm()
 

--- a/presentation/src/main/kotlin/com/woory/presentation/background/notification/NotificationProvider.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/notification/NotificationProvider.kt
@@ -1,6 +1,7 @@
 package com.woory.presentation.background.notification
 
 import android.app.PendingIntent
+import android.app.TaskStackBuilder
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
@@ -13,7 +14,8 @@ import com.woory.presentation.model.PromiseAlarm
 
 object NotificationProvider {
     const val PROMISE_READY_NOTIFICATION_ID = 80
-    const val PROMISE_START_NOTIFICATION_ID = 81
+    const val PROMISE_READY_COMPLETE_NOTIFICATION_ID = 81
+    const val PROMISE_START_NOTIFICATION_ID = 82
 
     fun createNotificationBuilder(
         context: Context,
@@ -36,16 +38,16 @@ object NotificationProvider {
         }
     }
 
-    fun notifyPromiseReadyNotification(
+    fun notifyBroadcastNotification(
         context: Context,
         title: String,
         content: String,
-        promiseAlarm: PromiseAlarm?,
+        promiseAlarm: PromiseAlarm,
     ) {
         val notificationManager = NotificationManagerCompat.from(context)
 
         val intent = Intent(context, AlarmTouchReceiver::class.java)
-        promiseAlarm?.let { intent.putPromiseAlarm(it) }
+        intent.putPromiseAlarm(promiseAlarm)
 
         val pendingIntent = PendingIntent.getBroadcast(
             context,
@@ -65,33 +67,31 @@ object NotificationProvider {
         notificationManager.notify(PROMISE_READY_NOTIFICATION_ID, notification.build())
     }
 
-    fun notifyPromiseStartNotification(
+    fun notifyActivityNotification(
         context: Context,
         title: String,
         content: String,
         promiseAlarm: PromiseAlarm,
+        intentClass: Class<*>,
     ) {
         val notificationManager = NotificationManagerCompat.from(context)
 
-        val intent = Intent(context, AlarmTouchReceiver::class.java).apply {
-            putPromiseAlarm(promiseAlarm)
-        }
+        val intent = Intent(context, intentClass)
+        intent.putPromiseAlarm(promiseAlarm)
 
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            PROMISE_START_NOTIFICATION_ID,
-            intent,
-            PendingIntent.FLAG_IMMUTABLE
-        )
+        val pendingIntent: PendingIntent = TaskStackBuilder.create(context).run {
+            addNextIntentWithParentStack(intent)
+            getPendingIntent(PROMISE_READY_COMPLETE_NOTIFICATION_ID, PendingIntent.FLAG_IMMUTABLE)
+        } ?: return
 
         val notification = createNotificationBuilder(
             context,
-            NotificationChannelProvider.PROMISE_START_CHANNEL_ID,
+            NotificationChannelProvider.PROMISE_READY_CHANNEL_ID,
             title,
             content,
             NotificationCompat.PRIORITY_HIGH,
             pendingIntent,
         )
-        notificationManager.notify(PROMISE_START_NOTIFICATION_ID, notification.build())
+        notificationManager.notify(PROMISE_READY_NOTIFICATION_ID, notification.build())
     }
 }

--- a/presentation/src/main/kotlin/com/woory/presentation/background/notification/NotificationProvider.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/notification/NotificationProvider.kt
@@ -40,12 +40,12 @@ object NotificationProvider {
         context: Context,
         title: String,
         content: String,
-        promiseAlarm: PromiseAlarm,
+        promiseAlarm: PromiseAlarm?,
     ) {
         val notificationManager = NotificationManagerCompat.from(context)
 
         val intent = Intent(context, AlarmTouchReceiver::class.java)
-        intent.putPromiseAlarm(promiseAlarm)
+        promiseAlarm?.let { intent.putPromiseAlarm(it) }
 
         val pendingIntent = PendingIntent.getBroadcast(
             context,

--- a/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseGameService.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseGameService.kt
@@ -2,6 +2,7 @@ package com.woory.presentation.background.service
 
 import android.app.PendingIntent
 import android.app.Service
+import android.app.TaskStackBuilder
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
@@ -9,19 +10,19 @@ import androidx.core.app.NotificationCompat
 import com.woory.almostthere.background.notification.NotificationChannelProvider
 import com.woory.presentation.R
 import com.woory.presentation.background.notification.NotificationProvider
+import com.woory.presentation.ui.gaming.GamingActivity
 import com.woory.presentation.ui.promises.PromisesActivity
 
 class PromiseGameService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        val intent = Intent(this, PromisesActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            NotificationProvider.PROMISE_START_NOTIFICATION_ID,
-            intent,
-            PendingIntent.FLAG_IMMUTABLE
-        )
+        val intent = Intent(this, GamingActivity::class.java)
+
+        val pendingIntent: PendingIntent = TaskStackBuilder.create(this).run {
+            addNextIntentWithParentStack(intent)
+            getPendingIntent(NotificationProvider.PROMISE_START_NOTIFICATION_ID, PendingIntent.FLAG_IMMUTABLE)
+        } ?: return
 
         val notification = NotificationProvider.createNotificationBuilder(
             this,

--- a/presentation/src/main/kotlin/com/woory/presentation/background/util/Extensions.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/util/Extensions.kt
@@ -3,12 +3,13 @@ package com.woory.presentation.background.util
 import android.content.Intent
 import com.woory.presentation.model.PromiseAlarm
 import com.woory.presentation.model.asAlarmState
+import com.woory.presentation.util.PROMISE_CODE_KEY
 import com.woory.presentation.util.TimeConverter.asMillis
 import com.woory.presentation.util.TimeConverter.asOffsetDateTime
 
 fun Intent.putPromiseAlarm(promiseAlarm: PromiseAlarm) {
     this.putExtra("alarmCode", promiseAlarm.alarmCode)
-    this.putExtra("promiseCode", promiseAlarm.promiseCode)
+    this.putExtra(PROMISE_CODE_KEY, promiseAlarm.promiseCode)
     this.putExtra("state", promiseAlarm.state.current)
     this.putExtra("startTime", promiseAlarm.startTime.asMillis())
     this.putExtra("endTime", promiseAlarm.endTime.asMillis())
@@ -18,7 +19,7 @@ fun Intent.asPromiseAlarm(): PromiseAlarm {
     val extras = this.extras ?: throw IllegalArgumentException("is extras null")
     val alarmCode = extras.getInt("alarmCode")
     val promiseCode =
-        extras.getString("promiseCode") ?: throw IllegalArgumentException("is promise code null")
+        extras.getString(PROMISE_CODE_KEY) ?: throw IllegalArgumentException("is promise code null")
     val state = extras.getString("state") ?: throw IllegalArgumentException("is state null")
     val startTime = extras.getLong("startTime")
     val endTime = extras.getLong("endTime")

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -77,5 +77,7 @@
     <string name="notification_channel_promise_start_description">게임 시작시 게임 진행 알림을 받는 채널입니다.</string>
     <string name="notification_start_title">게임이 진행중 입니다.</string>
     <string name="notification_start_content">자기장을 피해 약속 장소로 이동하세요.</string>
+    <string name="notification_ready_complete_title">게임 준비 완료</string>
+    <string name="notification_ready_complete_content">게임 준비가 완료되었습니다. 약속 정보를 확인하려면 터치하세요.</string>
     <string name="unknown_error" />
 </resources>


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#77

## 작업 내용 요약

- 게임 준비 Notification 터치시 게임 준비 완료 Notification 생성
- 게임 준비 Notification 터치시 게임 상세 정보 화면으로 이동
- MainActivity를 백스택에 포함된 채로 Activity 실행하도록 변경

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?