### PR TITLE
게임 종료 로직 구현

### DIFF
--- a/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
@@ -116,4 +116,10 @@ class DefaultPromiseRepository @Inject constructor(
 
     override suspend fun getGameRealtimeRanking(gameCode: String): Flow<Result<List<AddedUserHpModel>>> =
         firebaseDataSource.getGameRealtimeRanking(gameCode)
+
+    override suspend fun setIsFinishedPromise(gameCode: String): Result<Unit> =
+        firebaseDataSource.setIsFinishedPromise(gameCode)
+
+    override suspend fun getIsFinishedPromise(gameCode: String): Flow<Result<Boolean>> =
+        firebaseDataSource.getIsFinishedPromise(gameCode)
 }

--- a/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
@@ -67,4 +67,8 @@ interface PromiseRepository {
     suspend fun getPlayerArrived(gameCode: String, token: String): Flow<Result<Boolean>>
 
     suspend fun getGameRealtimeRanking(gameCode: String): Flow<Result<List<AddedUserHpModel>>>
+
+    suspend fun setIsFinishedPromise(gameCode: String): Result<Unit>
+
+    suspend fun getIsFinishedPromise(gameCode: String): Flow<Result<Boolean>>
 }

--- a/data/src/main/kotlin/com/woory/data/source/FirebaseDataSource.kt
+++ b/data/src/main/kotlin/com/woory/data/source/FirebaseDataSource.kt
@@ -50,4 +50,8 @@ interface FirebaseDataSource {
     suspend fun getPlayerArrived(gameCode: String, token: String): Flow<Result<Boolean>>
 
     suspend fun getGameRealtimeRanking(gameCode: String): Flow<Result<List<AddedUserHpModel>>>
+
+    suspend fun setIsFinishedPromise(gameCode: String): Result<Unit>
+
+    suspend fun getIsFinishedPromise(gameCode: String): Flow<Result<Boolean>>
 }

--- a/firebase/src/main/kotlin/com/woory/firebase/datasource/DefaultFirebaseDataSource.kt
+++ b/firebase/src/main/kotlin/com/woory/firebase/datasource/DefaultFirebaseDataSource.kt
@@ -548,7 +548,7 @@ class DefaultFirebaseDataSource @Inject constructor(
                 fireStore
                     .collection(PROMISE_COLLECTION_NAME)
                     .document(gameCode)
-                    .update("finished", true)
+                    .update(FINISHED_PROMISE_KEY, true)
             }
 
             when (val exception = result.exceptionOrNull()) {

--- a/firebase/src/main/kotlin/com/woory/firebase/model/PromiseData.kt
+++ b/firebase/src/main/kotlin/com/woory/firebase/model/PromiseData.kt
@@ -10,7 +10,8 @@ data class PromiseDocument(
     val host: PromiseParticipantField = PromiseParticipantField(),
     val gameTime: Timestamp = Timestamp(1, 1),
     val promiseTime: Timestamp = Timestamp(1, 1),
-    val users: List<PromiseParticipantField> = listOf()
+    val users: List<PromiseParticipantField> = listOf(),
+    val finished: Boolean = false
 )
 
 data class PromiseParticipantField(

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -81,6 +81,11 @@
             android:name=".background.service.AlarmRestartService"
             android:enabled="true"
             android:exported="false" />
+
+        <service
+            android:name=".background.service.PromiseFinishService"
+            android:enabled="true"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/presentation/src/main/kotlin/com/woory/presentation/background/receiver/AlarmReceiver.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/receiver/AlarmReceiver.kt
@@ -4,10 +4,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import com.woory.presentation.background.notification.NotificationChannelProvider
 import com.woory.presentation.background.notification.NotificationProvider
 import com.woory.presentation.R
 import com.woory.presentation.background.service.PromiseAlarmRegisterService
+import com.woory.presentation.background.service.PromiseFinishService
 import com.woory.presentation.background.service.PromiseGameService
 import com.woory.presentation.background.util.asPromiseAlarm
 import com.woory.presentation.background.util.putPromiseAlarm
@@ -31,8 +33,15 @@ class AlarmReceiver : BroadcastReceiver() {
                 onReceivePromiseStart(context, promiseAlarm)
             }
             AlarmState.END -> {
-
+                onReceivePromiseEnd(context, promiseAlarm)
             }
+        }
+    }
+
+    private fun onReceivePromiseEnd(context: Context, promiseAlarm: PromiseAlarm) {
+        Intent(context, PromiseFinishService::class.java).run {
+            putPromiseAlarm(promiseAlarm)
+            context.startServiceBp(this)
         }
     }
 

--- a/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseAlarmRegisterService.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseAlarmRegisterService.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.coroutineScope
+import androidx.lifecycle.lifecycleScope
 import com.woory.data.repository.PromiseRepository
 import com.woory.presentation.R
 import com.woory.presentation.background.alarm.AlarmFunctions
@@ -15,6 +16,7 @@ import com.woory.presentation.background.util.asPromiseAlarm
 import com.woory.presentation.model.mapper.alarm.asDomain
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -44,23 +46,22 @@ class PromiseAlarmRegisterService : LifecycleService() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        super.onStartCommand(intent, flags, startId)
         intent ?: throw IllegalArgumentException("intent is null")
 
         val promiseAlarm = intent.asPromiseAlarm()
 
-        lifecycle.coroutineScope.launch {
+        lifecycleScope.launch {
             repository.setPromiseAlarmByPromiseAlarmModel(promiseAlarm.asDomain())
                 .onSuccess {
                     alarmFunctions.registerAlarm(promiseAlarm)
                 }
                 .onFailure {
-                    Log.d("ERROR", "Failure register alarm")
+                    Timber.tag("ERROR").d("Failure register alarm")
                 }
                 .also {
                     stopSelf()
                 }
         }
-        return START_NOT_STICKY
+        return super.onStartCommand(intent, flags, startId)
     }
 }

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingActivity.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingActivity.kt
@@ -11,12 +11,16 @@ import androidx.activity.viewModels
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
+import androidx.lifecycle.lifecycleScope
 import com.woory.presentation.R
 import com.woory.presentation.databinding.ActivityGameResultBinding
 import com.woory.presentation.ui.BaseActivity
+import com.woory.presentation.ui.gameresult.GameResultActivity
 import com.woory.presentation.util.PROMISE_CODE_KEY
 import com.woory.presentation.util.REQUIRE_PERMISSION_TEXT
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class GamingActivity : BaseActivity<ActivityGameResultBinding>(R.layout.activity_gaming) {
@@ -45,6 +49,7 @@ class GamingActivity : BaseActivity<ActivityGameResultBinding>(R.layout.activity
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setOnListenIsFinished()
         viewModel.setGameCode(gameCode)
         bitmap?.let {
             viewModel.setDefaultMarker(it)
@@ -59,6 +64,17 @@ class GamingActivity : BaseActivity<ActivityGameResultBinding>(R.layout.activity
         ) {
             requestPermissionLauncher.launch(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
             return
+        }
+    }
+
+    private fun setOnListenIsFinished() {
+        lifecycleScope.launch {
+            viewModel.isFinished.collectLatest { isFinised ->
+                if (isFinised) {
+                    GameResultActivity.startActivity(this@GamingActivity,  gameCode)
+                    finish()
+                }
+            }
         }
     }
 

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -140,7 +141,7 @@ class GamingViewModel @Inject constructor(
                         }
 
                         launch {
-                            promiseRepository.getIsFinishedPromise(code).collect() { result ->
+                            promiseRepository.getIsFinishedPromise(code).collectLatest { result ->
                                 result.onSuccess { isFinished ->
                                     _isFinished.emit(isFinished)
                                 }

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingViewModel.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.skt.tmap.TMapPoint
-import com.skt.tmap.overlay.TMapMarkerItem
 import com.skt.tmap.overlay.TMapMarkerItem2
 import com.woory.data.repository.PromiseRepository
 import com.woory.data.repository.UserRepository
@@ -53,6 +52,12 @@ class GamingViewModel @Inject constructor(
     private val _allUsers: MutableStateFlow<List<String>?> = MutableStateFlow(null)
     val allUsers: StateFlow<List<String>?> = _allUsers.asStateFlow()
 
+    private val _isArrived: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isArrived: StateFlow<Boolean> = _isArrived.asStateFlow()
+
+    private val _isFinished: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isFinished: StateFlow<Boolean> = _isFinished.asStateFlow()
+
     private val userMarkers: MutableMap<String, TMapMarkerItem2> = mutableMapOf()
 
     val userHpMap: MutableMap<String, MutableStateFlow<AddedUserHp?>> = mutableMapOf()
@@ -65,9 +70,6 @@ class GamingViewModel @Inject constructor(
     val userNameMap: MutableMap<String, MutableStateFlow<String>> = mutableMapOf()
 
     val myUserInfo = runBlocking { userRepository.userPreferences.first() }
-
-    private val _isArrived: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isArrived: StateFlow<Boolean> = _isArrived.asStateFlow()
 
     fun setGameCode(code: String) {
         viewModelScope.launch {
@@ -133,6 +135,14 @@ class GamingViewModel @Inject constructor(
                             promiseRepository.getPlayerArrived(code, myUserInfo.userID).collect() { result ->
                                 result.onSuccess { isArrived ->
                                     _isArrived.emit(isArrived)
+                                }
+                            }
+                        }
+
+                        launch {
+                            promiseRepository.getIsFinishedPromise(code).collect() { result ->
+                                result.onSuccess { isFinished ->
+                                    _isFinished.emit(isFinished)
                                 }
                             }
                         }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -86,6 +86,9 @@
     <string name="notification_ready_complete_title">게임 준비 완료</string>
     <string name="notification_ready_complete_content">게임 준비가 완료되었습니다. 약속 정보를 확인하려면 터치하세요.</string>
     <string name="notification_alarm_restart">알람 재 등록중</string>
+    <string name="notification_finish_promise_title">게임 종료 중</string>
+    <string name="notification_finished_title">게임 종료!</string>
+    <string name="notification_finished_content">게임이 종료되었습니다. 게임 결과를 확인하려면 터치하세요.</string>
     <string name="unknown_error" />
     <string name="past_promise_history">과거 약속 정보</string>
     <string name="future_promise_history">미래 약속 정보</string>


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#112

## 작업 내용 요약

### 게임 종료 Alarm Event 발생

- BroadcastReceiver 에서 게임 종료 Service 실행
- Service에서 FireStore 게임 종료 값 True로 업데이트
- Notification 알림

### Fragment 게임 종료 처리

- Flow로 게임 종료 옵저빙
- 게임 종료 시 게임 결과 화면으로 이동

### 게임 진행 Service 에서 게임 종료 처리

- 해당 게임의 모든 Job Cancel
- 모든 게임이 종료된 상태라면 Service 종료

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?