### PR TITLE
Pending Intent 등록 전 이전 PendingIntent 취소 후 등록 / Service Notification 재실행 방지

### DIFF
--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmFunctions.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmFunctions.kt
@@ -24,6 +24,8 @@ class AlarmFunctions(private val context: Context) {
         }.asMillis()
 
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+        initBroadcastPendingIntent(promiseAlarm.alarmCode)
+
         val receiverIntent = Intent(context, AlarmReceiver::class.java)
         receiverIntent.apply {
             putPromiseAlarm(promiseAlarm)
@@ -31,7 +33,7 @@ class AlarmFunctions(private val context: Context) {
 
         val pendingIntent = PendingIntent.getBroadcast(
             context,
-            promiseAlarm.alarmCode + (1..100000).random(),
+            promiseAlarm.alarmCode,
             receiverIntent,
             PendingIntent.FLAG_IMMUTABLE
         )
@@ -56,4 +58,11 @@ class AlarmFunctions(private val context: Context) {
 
         alarmManager.cancel(pendingIntent)
     }
+
+    private fun initBroadcastPendingIntent(alarmCode: Int) = PendingIntent.getBroadcast(
+        context,
+        alarmCode,
+        Intent(context, AlarmReceiver::class.java),
+        PendingIntent.FLAG_IMMUTABLE
+    ).cancel()
 }

--- a/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseGameService.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseGameService.kt
@@ -20,6 +20,7 @@ import com.google.android.gms.location.Priority
 import com.woory.data.repository.PromiseRepository
 import com.woory.data.repository.UserRepository
 import com.woory.presentation.R
+import com.woory.presentation.background.alarm.AlarmFunctions
 import com.woory.presentation.background.notification.NotificationChannelProvider
 import com.woory.presentation.background.notification.NotificationProvider
 import com.woory.presentation.background.util.asPromiseAlarm
@@ -215,12 +216,10 @@ class PromiseGameService : LifecycleService() {
             putPromiseAlarm(promiseAlarm)
         }
 
-        val randomCode = promiseAlarm.alarmCode + (1..1000000).random()
-
         val pendingIntent: PendingIntent = TaskStackBuilder.create(this).run {
             addNextIntentWithParentStack(intent)
             getPendingIntent(
-                randomCode,
+                promiseAlarm.alarmCode,
                 PendingIntent.FLAG_IMMUTABLE
             )
         } ?: return
@@ -237,7 +236,7 @@ class PromiseGameService : LifecycleService() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             NotificationChannelProvider.providePromiseStartChannel(this)
         }
-        startForeground(randomCode, notification)
+        startForeground(promiseAlarm.alarmCode, notification)
     }
 
     private fun stopUpdateLocation() {

--- a/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseGameService.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/service/PromiseGameService.kt
@@ -212,6 +212,10 @@ class PromiseGameService : LifecycleService() {
     }
 
     private fun startForeground(promiseAlarm: PromiseAlarm) {
+        if (jobByGame.values.isNotEmpty()) {
+            return
+        }
+
         val intent = Intent(this, GamingActivity::class.java).apply {
             putPromiseAlarm(promiseAlarm)
         }


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#113

## 작업 내용 요약

- Pending Intent 등록 전 이전 PendingIntent 취소 후 등록하도록 수정
- 게임 진행 중일 때 Service Notification 다시 발생하지 않도록 수정

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?