### PR TITLE
다크모드 대응 및 status bar 투명하게 변경, toolbar에 bind:title하는 코드 삭제

### DIFF
--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gameresult/GameResultActivity.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gameresult/GameResultActivity.kt
@@ -25,7 +25,7 @@ class GameResultActivity : BaseActivity<ActivityGameResultBinding>(R.layout.acti
 
     private fun setUpToolbar() {
         setSupportActionBar(binding.containerToolbar.toolbar)
-        binding.containerToolbar.toolbar.title = getString(R.string.promise_creation)
+        binding.containerToolbar.toolbar.title = getString(R.string.calculate)
         supportActionBar?.let {
             it.setDisplayHomeAsUpEnabled(true)
             it.setDisplayShowHomeEnabled(true)

--- a/presentation/src/main/res/layout/activity_game_result.xml
+++ b/presentation/src/main/res/layout/activity_game_result.xml
@@ -14,7 +14,6 @@
             layout="@layout/layout_toolbar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            bind:title="@{@string/calculate}"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/presentation/src/main/res/layout/layout_toolbar.xml
+++ b/presentation/src/main/res/layout/layout_toolbar.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <data>
-        <variable
-            name="title"
-            type="String" />
-    </data>
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
@@ -16,7 +11,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            app:title="@{title}"
-            app:titleTextAppearance="@style/Text18.Black.Bold"/>
+            app:titleTextAppearance="@style/Text18.Black.Bold"
+            tools:title="title"/>
     </com.google.android.material.appbar.AppBarLayout>
 </layout>

--- a/presentation/src/main/res/values-night/themes.xml
+++ b/presentation/src/main/res/values-night/themes.xml
@@ -1,16 +1,56 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <!-- Base application theme. -->
-    <style name="Theme.AlmostThere" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.AlmostThere" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorPrimary">@color/almost_there_primary_dark</item>
+        <item name="colorPrimaryVariant">@color/almost_there_primary</item>
         <item name="colorOnPrimary">@color/black</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondary">@color/almost_there_primary_light</item>
+        <item name="colorSecondaryVariant">@color/almost_there_primary</item>
+        <item name="colorOnSecondary">@color/almost_there_black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+    </style>
+
+    <style name="Theme.AlmostThere.Splash" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/almost_there_primary</item>
+        <item name="android:background">@color/splash_background</item>
+    </style>
+
+    <style name="AlmostThere" />
+
+    <style name="AlmostThere.Main" />
+
+    <style name="AlmostThere.Clickable">
+        <item name="android:textSize">40sp</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="AlmostThere.Clickable.Left">
+        <item name="android:layout_marginStart">20dp</item>
+    </style>
+
+    <style name="AlmostThere.Clickable.Left.Main">
+        <item name="android:layout_marginTop">40dp</item>
+    </style>
+
+    <style name="AlmostThere.Clickable.Left.Specific">
+        <item name="android:layout_marginTop">60dp</item>
+    </style>
+
+    <style name="AlmostThere.Clickable.Right">
+        <item name="android:layout_marginEnd">20dp</item>
+    </style>
+
+    <style name="AlmostThere.Clickable.Right.Main">
+        <item name="android:layout_marginTop">40dp</item>
+    </style>
+
+    <style name="AlmostThere.Clickable.Right.Specific">
+        <item name="android:layout_marginTop">60dp</item>
     </style>
 </resources>

--- a/presentation/src/main/res/values-night/themes.xml
+++ b/presentation/src/main/res/values-night/themes.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.AlmostThere" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
@@ -10,11 +10,14 @@
         <item name="colorSecondaryVariant">@color/almost_there_primary</item>
         <item name="colorOnSecondary">@color/almost_there_black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
+        <item name="android:enforceStatusBarContrast" tools:targetApi="q">false</item>
     </style>
 
-    <style name="Theme.AlmostThere.Splash" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="colorPrimary">@color/almost_there_primary</item>
+    <style name="Theme.AlmostThere.Splash">
+        <item name="android:windowLightStatusBar">true</item>
         <item name="android:background">@color/splash_background</item>
     </style>
 

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.AlmostThere" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
@@ -10,13 +10,16 @@
         <item name="colorSecondaryVariant">@color/almost_there_primary_dark</item>
         <item name="colorOnSecondary">@color/almost_there_black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
+        <item name="android:enforceStatusBarContrast" tools:targetApi="q">false</item>
         <!-- Customize your theme here. -->
         <item name="android:windowBackground">@color/cream</item>
     </style>
 
-    <style name="Theme.AlmostThere.Splash" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="colorPrimary">@color/almost_there_primary</item>
+    <style name="Theme.AlmostThere.Splash">
         <item name="android:background">@color/splash_background</item>
     </style>
 


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#106
- resolved boostcampwm-2022/android11-almost-there#131

## 작업 내용 요약

- 다크모드 대응
- status bar 투명하게 변경
- toolbar에 bind:title 하는 코드 삭제

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?