### PR TITLE
약속 정보 화면 관련 버그 수정

### DIFF
--- a/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmFunctions.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/background/alarm/AlarmFunctions.kt
@@ -16,9 +16,7 @@ class AlarmFunctions(private val context: Context) {
         promiseAlarm: PromiseAlarm
     ) {
         val timeInMillis = when (promiseAlarm.state) {
-//            ALARM_STATUS_READY -> promiseAlarm.startTime.minusMinutes(5)
-            // Todo :: 테스트용 코드
-            AlarmState.READY -> promiseAlarm.startTime.minusSeconds(5)
+            AlarmState.READY -> promiseAlarm.startTime.minusMinutes(5)
             AlarmState.START -> promiseAlarm.startTime
             AlarmState.END -> promiseAlarm.endTime
         }.asMillis()

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseFragment.kt
@@ -144,19 +144,7 @@ class CreatingPromiseFragment :
 
                 launch {
                     viewModel.promiseSettingEvent.collectLatest { promiseAlarm ->
-//                        alarmFunctions.registerAlarm(promiseAlarm)
-
-                        //Todo :: 테스트용 코드{
-                        alarmFunctions.registerAlarm(
-                            PromiseAlarm(
-                                alarmCode = promiseAlarm.alarmCode,
-                                promiseCode = promiseAlarm.promiseCode,
-                                state = promiseAlarm.state,
-                                startTime = OffsetDateTime.now().plusSeconds(10),
-                                endTime = OffsetDateTime.now().plusSeconds(30)
-                            )
-                        )
-
+                        alarmFunctions.registerAlarm(promiseAlarm)
                         viewModel.setPromiseAlarm(promiseAlarm)
 
                         PromiseInfoActivity.startActivity(

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
@@ -104,6 +104,7 @@ class PromiseInfoFragment :
         }
 
         binding.btnCodeShare.setOnClickListener {
+            shareCode()
 //            shareCode(viewModel.gameCode.value)
         }
 
@@ -237,6 +238,10 @@ class PromiseInfoFragment :
                 }
             }
         }
+    }
+
+    private fun shareCode() {
+        makeSnackBar(getString(R.string.snack_bar_not_implementation))
     }
 
     // TODO : 카카오톡 공유 코드

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoFragment.kt
@@ -5,6 +5,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context.CLIPBOARD_SERVICE
 import android.content.pm.PackageManager
+import android.graphics.PointF
 import android.os.Bundle
 import android.view.View
 import androidx.core.app.ActivityCompat
@@ -19,7 +20,9 @@ import com.google.android.gms.location.LocationServices
 import com.google.android.material.snackbar.Snackbar
 import com.skt.tmap.TMapPoint
 import com.skt.tmap.TMapView
+import com.skt.tmap.TMapView.OnClickListenerCallback
 import com.skt.tmap.overlay.TMapMarkerItem
+import com.skt.tmap.poi.TMapPOIItem
 import com.woory.presentation.BuildConfig
 import com.woory.presentation.R
 import com.woory.presentation.background.alarm.AlarmFunctions
@@ -34,6 +37,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.threeten.bp.Duration
+import java.util.ArrayList
 
 @AndroidEntryPoint
 class PromiseInfoFragment :
@@ -61,6 +65,7 @@ class PromiseInfoFragment :
             LocationServices.getFusedLocationProviderClient(requireActivity())
 
         setUpMapView()
+        setDisableMapViewTouchInterceptor()
         setUpButtonListener()
         setUsers()
 
@@ -166,6 +171,29 @@ class PromiseInfoFragment :
             removeAllTMapMarkerItem()
             addTMapMarkerItem(marker)
         }
+    }
+
+    private fun setDisableMapViewTouchInterceptor() {
+        mapView.setOnClickListenerCallback(object: OnClickListenerCallback {
+            override fun onPressDown(
+                p0: ArrayList<TMapMarkerItem>?,
+                p1: ArrayList<TMapPOIItem>?,
+                p2: TMapPoint?,
+                p3: PointF?
+            ) {
+                binding.scrollView.requestDisallowInterceptTouchEvent(true)
+            }
+
+            override fun onPressUp(
+                p0: ArrayList<TMapMarkerItem>?,
+                p1: ArrayList<TMapPOIItem>?,
+                p2: TMapPoint?,
+                p3: PointF?
+            ) {
+                binding.scrollView.requestDisallowInterceptTouchEvent(false)
+            }
+
+        })
     }
 
     private fun readyGame() {

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/promiseinfo/PromiseInfoViewModel.kt
@@ -106,14 +106,14 @@ class PromiseInfoViewModel @Inject constructor(
                     _gameTime.emit(
                         promiseModel.data.gameDateTime.format(
                             DateTimeFormatter.ofPattern(
-                                "yyyy.MM.dd hh:mm"
+                                "yyyy.MM.dd a hh:mm"
                             )
                         )
                     )
                     _promiseTime.emit(
                         promiseModel.data.promiseDateTime.format(
                             DateTimeFormatter.ofPattern(
-                                "yyyy.MM.dd hh:mm"
+                                "yyyy.MM.dd a hh:mm"
                             )
                         )
                     )

--- a/presentation/src/main/res/layout/fragment_promise_info.xml
+++ b/presentation/src/main/res/layout/fragment_promise_info.xml
@@ -23,6 +23,7 @@
         android:layout_height="match_parent">
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/scrollView"
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:layout_constraintBottom_toTopOf="@id/btn_ready"
@@ -47,19 +48,11 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline_center"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    app:layout_constraintGuide_percent="0.5" />
-
                 <FrameLayout
                     android:id="@+id/container_map"
                     android:layout_width="0dp"
-                    android:layout_height="0dp"
+                    android:layout_height="400dp"
                     android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
-                    app:layout_constraintBottom_toBottomOf="@id/guideline_center"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
@@ -74,7 +67,7 @@
                     android:textStyle="italic|bold"
                     android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/guideline_center" />
+                    app:layout_constraintTop_toBottomOf="@id/container_map" />
 
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/btn_code_copy"
@@ -98,7 +91,7 @@
                     android:visibility="@{vm.uiState instanceof PromiseUiState.Fail ? View.GONE : View.VISIBLE}"
                     app:layout_constraintBottom_toBottomOf="@id/btn_code_copy"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/guideline_center"
+                    app:layout_constraintTop_toBottomOf="@id/container_map"
                     app:layout_goneMarginTop="10dp" />
 
                 <androidx.cardview.widget.CardView

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -151,4 +151,5 @@
     <string name="game_time_hint">게임 시간 설정...</string>
     <string name="my_ranking">내 순위 : %d위</string>
     <string name="location_title">위치</string>
+    <string name="snack_bar_not_implementation">"아직 구현되지 않은 기능입니다."</string>
 </resources>


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#171
- resolved boostcampwm-2022/android11-almost-there#172
- resolved boostcampwm-2022/android11-almost-there#173
- resolved boostcampwm-2022/android11-almost-there#175

## 작업 내용 요약

- 카카오톡 공유 배포시 구현 가능한 사항이라, 배포 이전에 기능을 사용하지 못하도록 수정
- 약속 관련 테스트용 코드 삭제
- 약속 정보 화면 DateTimeFormatter 에서 a를 추가
- 약속 정보 화면 MapView 터치시 ScrollView 동작하지 않도록 수정

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?