### PR TITLE
도착 관련 버그, 게임 참여시 Notification 바로 발생하는 버그 수정

### DIFF
--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingFragment.kt
@@ -37,6 +37,7 @@ import com.woory.presentation.binding.bindImage
 import com.woory.presentation.databinding.CustomviewCharacterMarkerBinding
 import com.woory.presentation.databinding.FragmentGamingBinding
 import com.woory.presentation.model.GeoPoint
+import com.woory.presentation.model.UserLocation
 import com.woory.presentation.model.UserProfileImage
 import com.woory.presentation.ui.BaseFragment
 import com.woory.presentation.util.DistanceUtil.getDistance
@@ -143,6 +144,7 @@ class GamingFragment : BaseFragment<FragmentGamingBinding>(R.layout.fragment_gam
         dismissBottomSheet()
 
         setUpMapView()
+        setDetectIsArrived()
     }
 
     private fun setUpMapView() {
@@ -204,25 +206,7 @@ class GamingFragment : BaseFragment<FragmentGamingBinding>(R.layout.fragment_gam
                                                     removeTMapMarkerItem(user.userId)
                                                     addTMapMarkerItem(markerMap[user.userId])
                                                 }
-                                            }
-
-                                            launch {
-                                                viewModel.isArrived.collectLatest { isArrived ->
-                                                    if (isArrived) {
-                                                        binding.konfetti.start(festive())
-                                                        return@collectLatest
-                                                    }
-                                                    if (userLocation?.token == viewModel.myUserInfo.userID) {
-                                                        viewModel.magneticInfo.collectLatest { magneticInfo ->
-                                                            if (magneticInfo != null) {
-                                                                alertShakeDialog(
-                                                                    userLocation.geoPoint,
-                                                                    magneticInfo.centerPoint
-                                                                )
-                                                            }
-                                                        }
-                                                    }
-                                                }
+                                                checkIsArrived(userLocation)
                                             }
                                         }
                                     }
@@ -327,6 +311,32 @@ class GamingFragment : BaseFragment<FragmentGamingBinding>(R.layout.fragment_gam
         }
 
         binding.containerMap.addView(mapView)
+    }
+
+    private fun checkIsArrived(userLocation: UserLocation?) {
+        val centerPoint = viewModel.magneticInfo.value?.centerPoint
+
+        if (userLocation?.token == viewModel.myUserInfo.userID) {
+
+
+            if (centerPoint != null) {
+                alertShakeDialog(
+                    userLocation.geoPoint,
+                    centerPoint
+                )
+            }
+
+        }
+    }
+
+    private fun setDetectIsArrived() {
+        lifecycleScope.launch {
+            viewModel.isArrived.collectLatest { isArrived ->
+                if (isArrived) {
+                    binding.konfetti.start(festive())
+                }
+            }
+        }
     }
 
     private fun showPromiseInfo() {

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/join/ProfileActivity.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/join/ProfileActivity.kt
@@ -75,17 +75,7 @@ class ProfileActivity : BaseActivity<ActivityProfileBinding>(R.layout.activity_p
     }
 
     private fun registerAlarm(promiseAlarm: PromiseAlarm) {
-        // FIXME: 테스트용 코드
-        alarmFunctions.registerAlarm(
-            PromiseAlarm(
-                alarmCode = promiseAlarm.alarmCode,
-                promiseCode = promiseAlarm.promiseCode,
-                state = promiseAlarm.state,
-                startTime = OffsetDateTime.now().plusSeconds(10),
-                endTime = OffsetDateTime.now().plusSeconds(30)
-            )
-        )
-
+        alarmFunctions.registerAlarm(promiseAlarm)
         PromiseInfoActivity.startActivity(this@ProfileActivity, promiseAlarm.promiseCode)
         finish()
     }


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#205
- resolved boostcampwm-2022/android11-almost-there#207

## 작업 내용 요약

- 한 번 도착 알림이 발생한 이후, 그 지역을 벗어나도 계속해서 알림이 발생하는 현상 수정
- 도착 알림을 등록한 후 플레이어의 위치가 업데이트 될 때 마다 폭죽이 터지는 현상 수정
- 게임 참여시 Notification 바로 발생하는 현상 수정

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?