### PR TITLE
DialogFragment 강제 종료 및 게임 결과 화면에서 버그 수정

### DIFF
--- a/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/creatingpromise/CreatingPromiseFragment.kt
@@ -217,12 +217,12 @@ class CreatingPromiseFragment :
 
     private fun showCheckPromiseDataDialog(promiseData: PromiseData) {
         try {
-            if (!checkPromiseDataDialog.isAdded) {
-                checkPromiseDataDialog.setPromiseData(promiseData)
-                checkPromiseDataDialog.show(parentFragmentManager, CheckPromiseDataDialog.TAG)
-            }
+            checkPromiseDataDialog.setPromiseData(promiseData)
+            checkPromiseDataDialog.show(
+                parentFragmentManager.beginTransaction().remove(checkPromiseDataDialog),
+                CheckPromiseDataDialog.TAG
+            )
         } catch (e: Exception) {
-            println(e.stackTraceToString())
             val message = getExceptionMessage(requireContext(), e)
             showSnackBar(message)
         }

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gameresult/GameResultFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gameresult/GameResultFragment.kt
@@ -61,6 +61,7 @@ class GameResultFragment : BaseFragment<FragmentGameResultBinding>(R.layout.frag
 
             adapter = UserRankingAdapter()
 
+            itemAnimator = null
             addItemDecoration(TopItemResizeDecoration())
             addOnScrollListener(TopItemResizeScrollListener(linearLayoutManager))
         }
@@ -93,7 +94,10 @@ class GameResultFragment : BaseFragment<FragmentGameResultBinding>(R.layout.frag
                 launch {
                     viewModel.myRankingNumber.collectLatest {
                         binding.tvGameResultMyRanking.text =
-                            String.format(getString(R.string.my_ranking), it)
+                            String.format(
+                                getString(R.string.my_ranking),
+                                it?.toString() ?: getString(R.string.null_value)
+                            )
                     }
                 }
             }

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gameresult/GameResultViewModel.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gameresult/GameResultViewModel.kt
@@ -31,10 +31,10 @@ class GameResultViewModel @Inject constructor(
 
     private val userPreferences = userRepository.userPreferences
 
-    private val _myRankingNumber: MutableStateFlow<Int?> = MutableStateFlow(0)
+    private val _myRankingNumber: MutableStateFlow<Int?> = MutableStateFlow(null)
     val myRankingNumber: StateFlow<Int?> = _myRankingNumber.asStateFlow()
 
-    private val _mySplitMoney: MutableStateFlow<Int?> = MutableStateFlow(0)
+    private val _mySplitMoney: MutableStateFlow<Int?> = MutableStateFlow(null)
     val mySplitMoney: StateFlow<Int?> = _mySplitMoney.asStateFlow()
 
     private val _userSplitMoneyItems: MutableStateFlow<List<UserSplitMoneyItem>?> =

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gameresult/SplitMoneyFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gameresult/SplitMoneyFragment.kt
@@ -61,7 +61,7 @@ class SplitMoneyFragment : BaseFragment<FragmentSplitMoneyBinding>(R.layout.frag
                     viewModel.mySplitMoney.collectLatest {
                         binding.tvPayment.text = if (it != null) {
                             String.format(getString(R.string.payment), it)
-                        } else ""
+                        } else getString(R.string.null_value)
                     }
                 }
 

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingFragment.kt
@@ -419,10 +419,10 @@ class GamingFragment : BaseFragment<FragmentGamingBinding>(R.layout.fragment_gam
             dest
         )
 
-        if (distance < ARRIVE_STANDARD_LENGTH && !shakeDialog.isAdded) {
+        if (distance < ARRIVE_STANDARD_LENGTH) {
             shakeDialog.show(
-                parentFragmentManager,
-                shakeDialog.TAG
+                parentFragmentManager.beginTransaction().remove(shakeDialog),
+                ShakeDeviceFragment.TAG
             )
         }
     }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -149,7 +149,8 @@
     <string name="promise_time_hint">약속 시간 입력...</string>
     <string name="game_time_text">언제 출발하나요?</string>
     <string name="game_time_hint">게임 시간 설정...</string>
-    <string name="my_ranking">내 순위 : %d위</string>
+    <string name="my_ranking">내 순위 : %s위</string>
+    <string name="null_value">-</string>
     <string name="location_title">위치</string>
     <string name="promise_setting">약속 설정</string>
     <string name="game_setting">게임 설정</string>


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#184
- resolved boostcampwm-2022/android11-almost-there#196

## 작업 내용 요약

- 약속 생성 및 게임 진행화면에서 DialogFragment로 인한 강제 종료 버그 해결
- 게임 결과 화면에서 RecyclerView 버그, null 값일 때 "-" 처리

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?