### PR TITLE
약속 히스토리 카드에서 자기장 위치 조정되는 버그 수정, initial radius set 하는 위치 변경

### DIFF
--- a/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/DefaultPromiseRepository.kt
@@ -82,6 +82,9 @@ class DefaultPromiseRepository @Inject constructor(
     override suspend fun updateMagneticRadius(gameCode: String, radius: Double): Result<Unit> =
         firebaseDataSource.updateMagneticRadius(gameCode, radius)
 
+    override suspend fun updateInitialMagneticRadius(gameCode: String): Result<Unit> =
+        firebaseDataSource.updateInitialMagneticRadius(gameCode)
+
     override suspend fun decreaseMagneticRadius(
         gameCode: String,
         minusValue: Double

--- a/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
+++ b/data/src/main/kotlin/com/woory/data/repository/PromiseRepository.kt
@@ -49,6 +49,8 @@ interface PromiseRepository {
 
     suspend fun updateMagneticRadius(gameCode: String, radius: Double): Result<Unit>
 
+    suspend fun updateInitialMagneticRadius(gameCode: String): Result<Unit>
+
     suspend fun decreaseMagneticRadius(gameCode: String, minusValue: Double): Result<Unit>
 
     suspend fun checkReEntryOfGame(gameCode: String, token: String): Result<Boolean>

--- a/data/src/main/kotlin/com/woory/data/source/FirebaseDataSource.kt
+++ b/data/src/main/kotlin/com/woory/data/source/FirebaseDataSource.kt
@@ -29,7 +29,7 @@ interface FirebaseDataSource {
 
     suspend fun updateMagneticRadius(gameCode: String, radius: Double): Result<Unit>
 
-    suspend fun updateInitialMagneticRadius(gameCode: String, radius: Double): Result<Unit>
+    suspend fun updateInitialMagneticRadius(gameCode: String): Result<Unit>
 
     suspend fun decreaseMagneticRadius(gameCode: String, minusValue: Double): Result<Unit>
 

--- a/presentation/src/main/kotlin/com/woory/presentation/ui/history/PromiseHistoryAdapter.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/history/PromiseHistoryAdapter.kt
@@ -1,5 +1,6 @@
 package com.woory.presentation.ui.history
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -26,6 +27,7 @@ class PromiseHistoryAdapter(
     override fun onBindViewHolder(holder: PromiseHistoryViewHolder, position: Int) =
         holder.bind(getItem(position))
 
+    @SuppressLint("ClickableViewAccessibility")
     class PromiseHistoryViewHolder(
         private val binding: ItemPromiseHistoryBinding,
         private val onClick: (PromiseHistoryViewType?, PromiseHistory?) -> Unit
@@ -34,6 +36,9 @@ class PromiseHistoryAdapter(
         init {
             binding.root.setOnClickListener {
                 onClick(binding.type, binding.promiseHistory)
+            }
+            binding.progressLayout.progressbar.setOnTouchListener { _, _ ->
+                true
             }
         }
 

--- a/presentation/src/main/res/layout/item_promise_history.xml
+++ b/presentation/src/main/res/layout/item_promise_history.xml
@@ -121,6 +121,7 @@
             </HorizontalScrollView>
 
             <include
+                android:id="@+id/progressLayout"
                 layout="@layout/layout_history_progress"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/presentation/src/main/res/layout/layout_history_progress.xml
+++ b/presentation/src/main/res/layout/layout_history_progress.xml
@@ -42,21 +42,6 @@
                 app:layout_constraintTop_toBottomOf="@id/endThumb"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <androidx.appcompat.widget.AppCompatSeekBar
-                android:id="@+id/progressbar"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
-                android:drawableStart="@drawable/ic_rank_label"
-                android:progressTint="@color/red"
-                android:thumb="@drawable/ic_bomb"
-                app:indicatorColor="@color/black"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/startIcon"
-                app:progress="@{promiseHistory}" />
-
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/startThumb"
                 android:layout_width="wrap_content"
@@ -77,7 +62,23 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/endIcon" />
 
+            <androidx.appcompat.widget.AppCompatSeekBar
+                android:id="@+id/progressbar"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:layout_marginEnd="3dp"
+                android:drawableStart="@drawable/ic_rank_label"
+                android:progressTint="@color/red"
+                android:thumb="@drawable/ic_bomb"
+                app:indicatorColor="@color/black"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/startIcon"
+                app:progress="@{promiseHistory}" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </FrameLayout>
+
 </layout>


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#213

## 작업 내용 요약

- SeekBar에 touchListener 달기
- 초기 자기장 set 코드 Service 내부로 변경

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?