### PR TITLE
대중 교통 조회시 역 끼리의 소요시간만 가져와지는 문제 해결

### DIFF
--- a/network/src/main/kotlin/com/woory/network/DefaultNetworkDataSource.kt
+++ b/network/src/main/kotlin/com/woory/network/DefaultNetworkDataSource.kt
@@ -40,8 +40,32 @@ class DefaultNetworkDataSource @Inject constructor(
                 .getJSONObject(0)
                 .getJSONObject("info")
 
-            val time = routeInfo.getInt("totalTime")
+            val searchType = json.getInt("searchType")
+            var time = routeInfo.getInt("totalTime")
             val distance = routeInfo.getDouble("totalDistance")
+
+            if (searchType == 1) {
+                val stationInfo = json.getJSONArray("path")
+                    .getJSONObject(0)
+                    .getJSONArray("subPath")
+
+                val startStationInfo = stationInfo.getJSONObject(0)
+                val ssy = startStationInfo.getDouble("startY")
+                val ssx = startStationInfo.getDouble("startX")
+                val stationStartTime = getPublicTransitRoute(
+                    start = GeoPointModel(start.latitude, start.longitude),
+                    dest = GeoPointModel(ssy, ssx)
+                ).getOrThrow().time
+
+                val endStationInfo = stationInfo.getJSONObject(stationInfo.length() - 1)
+                val esy = endStationInfo.getDouble("endY")
+                val esx = endStationInfo.getDouble("endX")
+                val stationEndTime = getPublicTransitRoute(
+                    start = GeoPointModel(dest.latitude, dest.longitude),
+                    dest = GeoPointModel(esy, esx)
+                ).getOrThrow().time
+                time += stationStartTime + stationEndTime
+            }
 
             PathModel(
                 routeType = RouteType.PUBLIC_TRANSIT,


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#216

## 작업 내용 요약

- 출발 지 부터 역 으로 이동하는 시간, 도착 역으로부터 도착지까지 이동하는 시간 추가

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?