### PR TITLE
게이밍 화면 BottomSheet에서 남은 시간이 잘 나오지 않는 디자인 수정

### DIFF
--- a/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingFragment.kt
+++ b/presentation/src/main/kotlin/com/woory/presentation/ui/gaming/GamingFragment.kt
@@ -348,6 +348,7 @@ class GamingFragment : BaseFragment<FragmentGamingBinding>(R.layout.fragment_gam
 
     private fun showBottomSheet(id: String) {
         profileBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+        binding.layoutBottomSheet.tvExpectedTime.text = getString(R.string.loading_text)
 
         val image = viewModel.getUserImage(id) ?: defaultProfileImage
         binding.layoutBottomSheet.layoutCharacterImg.profileImage = image
@@ -372,7 +373,6 @@ class GamingFragment : BaseFragment<FragmentGamingBinding>(R.layout.fragment_gam
     private fun dismissBottomSheet() {
         profileBehavior.state = BottomSheetBehavior.STATE_HIDDEN
         promiseInfoBehavior.state = BottomSheetBehavior.STATE_HIDDEN
-        binding.layoutBottomSheet.tvExpectedTime.text = getString(R.string.loading_text)
     }
 
     private fun makeSnackBar(text: String) {


### PR DESCRIPTION
## Related Issue

- resolved boostcampwm-2022/android11-almost-there#218

## 작업 내용 요약

- 게이밍 화면 BottomSheet에서 남은 시간이 잘 나오지 않는 디자인 수정

## Checklist

- [x] Merge 되는 브랜치가 올바른가?
- [x] Reviewers, Assignees, Labels, Projects, Milestone 설정을 했는가?
- [x] 스스로 코드 리뷰를 충분히 진행했는가?
- [x] 프로젝트의 스타일 가이드라인(컨벤션)을 준수하는가?